### PR TITLE
Add benhepworth as maintainer so he can review PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @caubut-charter @mayur007 @RandyLevensalor
+* @caubut-charter @mayur007 @RandyLevensalor @benhepworth
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -4,3 +4,4 @@
 | CableLabs | Randy Levensalor | RandyLevensalor |
 | Vodafone | Mayur Channegowda | mayur007 |
 | Charter Communications | Justin Pace | justin-pace-charter |
+| CableLabs | Ben Hepworth | benhepworth |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

Add Ben Hepworth as codeowner and maintainer so he can review PRs. Will also need write access to the repo.

#### Which issue(s) this PR fixes:

Fixes #22