### PR TITLE
38 operator device capability discovery

### DIFF
--- a/code/API_definitions/Domain/Capabilities.yaml
+++ b/code/API_definitions/Domain/Capabilities.yaml
@@ -1,0 +1,118 @@
+components:
+  schemas:
+    title: Operator Device Capabilities
+    DeviceId:
+      $ref: './Common.yaml#/components/schemas/DeviceId'
+
+    DeviceCapabilities:
+      oneOf:
+        - $ref: '#/components/schemas/OperatorDeviceCapabilities'
+        - $ref: '#/components/schemas/ClientDeviceCapabilities'
+      discriminator:
+        propertyName: deviceType
+        mapping:
+          CPE: '#/components/schemas/OperatorDeviceCapabilities'
+          Client: '#/components/schemas/ClientDeviceCapabilities'
+
+    OperatorDeviceCapabilities:
+      type: object
+      description: Capabilities supported by a network operator-managed device (CPE)
+      required:
+        - deviceType
+      properties:
+        deviceType:
+          description: Consumers should inspect capabilities (e.g., wanConnected, supportsRouting, supportedNetworkTypes) to determine functional roles like gateway, router, or access point.
+          type: string
+          enum: [CPE]
+          default: CPE
+          example: CPE
+
+        supportedSecurityModes:
+          type: array
+          description: |
+            Supported security configurations for networks.
+            This includes Wi-Fi security modes (WPA2/WPA3 variants) and Thread-specific mechanisms (e.g., CASE, PASE).
+          items:
+            type: string
+            enum:
+              # Wi-Fi
+              - WPA2-Personal
+              - WPA3-Personal
+              - WPA2-Enterprise
+              - WPA3-Enterprise
+
+              # Thread
+              - Thread-NetworkKey
+              - DTLS
+              - PASE
+              - CASE
+          example: [WPA2-Personal, Thread-NetworkKey, CASE]
+        supportedNetworkTypes:
+          type: array
+          description: Physical or logical network types this device can support
+          items:
+            type: string
+          example: [Wi-Fi, Thread, Ethernet]
+
+        maxAuxiliaryNetworks:
+          type: integer
+          description: >-
+            Maximum amount of auxiliary networks the device supports for a given client.
+          minimum: 1
+          example: 2
+
+        onboardingProtocols:
+          type: array
+          description: |
+            Provisioning protocols supported for client device onboarding.
+            This implies support for zero-touch workflows.
+            Common values include DPP, Matter, or vendor-specific methods.
+          items:
+            type: string
+          example: [DPP, Matter, OnRamp]
+
+        networkFeatures:
+          type: object
+          description: Network-level functional capabilities
+          properties:
+            supportsRouting:
+              type: boolean
+            supportsTunneling:
+              type: boolean
+            supportedTunnelingTech:
+              type: array
+              items:
+                type: string
+              example: [IPSec, GRE, WireGuard]
+            wanConnected:
+              type: boolean
+            supportsTrustDomains:
+              type: boolean
+
+        telemetry:
+          type: object
+          description: Diagnostics and telemetry support
+          properties:
+            supportsDiagnostics:
+              type: boolean
+            supportsTelemetry:
+              type: boolean
+            metricsAvailable:
+              type: array
+              items:
+                type: string
+              example: [connected_clients, cpu_usage]
+
+    ClientDeviceCapabilities:
+      type: object
+      description: Capabilities supported by a client-side device (e.g., user laptop, IoT sensor)
+      required:
+        - deviceType
+      properties:
+        deviceType:
+          type: string
+          enum: [Client]
+          default: Client
+        note:
+          type: string
+          example: "Client capabilities not yet implemented."

--- a/code/API_definitions/Domain/Common.yaml
+++ b/code/API_definitions/Domain/Common.yaml
@@ -1,0 +1,19 @@
+# OpenAPI Specification for Common Definitions
+components:
+
+  parameters:
+    deviceIdParam:
+      name: deviceId
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/DeviceId'
+      description: ID of the device to retrieve capabilities for
+
+  schemas:
+    DeviceId:
+      type: string
+      minLength: 1
+      maxLength: 64
+      description: The unique identifier for a device
+      example: device-1

--- a/code/API_definitions/capabilities.yaml
+++ b/code/API_definitions/capabilities.yaml
@@ -1,11 +1,21 @@
 openapi: 3.0.3
 info:
   title: Device Capabilities
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.1.0
   description: |
     API to retrieve capability information about operator-supplied or client devices.
     Currently only operator device (CPE) capabilities are implemented.
     Support for client devices is reserved for future use.
+
+servers:
+  - url: "{apiRoot}/network-access-management/v0"
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 
 tags:
   - name: Retrieve Device Capabilities
@@ -17,139 +27,25 @@ paths:
       tags:
         - Retrieve Device Capabilities
       summary: Get capabilities for a device
+      security:
+        - openId:
+            - network-access-management:device:read
       operationId: getDeviceCapabilities
       parameters:
-        - name: deviceId
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/DeviceId'
-          description: ID of the device to retrieve capabilities for
+        - $ref: './Domain/Common.yaml#/components/parameters/deviceIdParam'
       responses:
         '200':
           description: Capabilities supported by the device
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceCapabilities'
+                $ref: './Domain/Capabilities.yaml#/components/schemas/DeviceCapabilities/'
         '404':
           description: Device not found
 
 components:
-  schemas:
 
-    DeviceId:
-      type: string
-      minLength: 1
-      maxLength: 64
-      description: The unique identifier for a device
-      example: device-1
-
-    DeviceCapabilities:
-      oneOf:
-        - $ref: '#/components/schemas/OperatorDeviceCapabilities'
-        - $ref: '#/components/schemas/ClientDeviceCapabilities'
-      discriminator:
-        propertyName: deviceType
-        mapping:
-          CPE: '#/components/schemas/OperatorDeviceCapabilities'
-          Client: '#/components/schemas/ClientDeviceCapabilities'
-
-    OperatorDeviceCapabilities:
-      type: object
-      description: Capabilities supported by a network operator-managed device (CPE)
-      required:
-        - deviceType
-      properties:
-        deviceType:
-          type: string
-          enum: [CPE]
-          default: CPE
-
-        supportedSecurityModes:
-          type: array
-          description: Supported security configurations for WiFi
-          items:
-            type: string
-            enum:
-              # Wi-Fi
-              - WPA2-Personal
-              - WPA3-Personal
-              - WPA2-Enterprise
-              - WPA3-Enterprise
-
-              # Thread
-              - Thread-NetworkKey
-              - DTLS
-              - PASE
-              - CASE
-          example: [WPA2-Personal, Thread-NetworkKey, CASE]
-        supportedNetworkTypes:
-          type: array
-          description: Physical or logical network types this device can support
-          items:
-            type: string
-          example: [Wi-Fi, Thread, Ethernet]
-
-        maxAuxiliaryNetworks:
-          type: integer
-          description: >-
-            Maximum amount of auxiliary networks the device supports for a given client.
-          minimum: 1
-          example: 2
-
-        onboardingProtocols:
-          type: array
-          description: |
-            Provisioning protocols supported for client device onboarding.
-            This implies support for zero-touch workflows.
-            Common values include DPP, Matter, or vendor-specific methods.
-          items:
-            type: string
-          example: [DPP, Matter, OnRamp]
-
-        networkFeatures:
-          type: object
-          description: Network-level functional capabilities
-          properties:
-            supportsRouting:
-              type: boolean
-            supportsTunneling:
-              type: boolean
-            supportedTunnelingTech:
-              type: array
-              items:
-                type: string
-              example: [IPSec, GRE, WireGuard]
-            wanConnected:
-              type: boolean
-            supportsTrustDomains:
-              type: boolean
-
-        telemetry:
-          type: object
-          description: Diagnostics and telemetry support
-          properties:
-            supportsDiagnostics:
-              type: boolean
-            supportsTelemetry:
-              type: boolean
-            metricsAvailable:
-              type: array
-              items:
-                type: string
-              example: [connected_clients, cpu_usage]
-
-    ClientDeviceCapabilities:
-      type: object
-      description: Capabilities supported by a client-side device (e.g., user laptop, IoT sensor)
-      required:
-        - deviceType
-      properties:
-        deviceType:
-          type: string
-          enum: [Client]
-          default: Client
-        note:
-          type: string
-          example: "Client capabilities not yet implemented."
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration

--- a/code/API_definitions/redocly.yaml
+++ b/code/API_definitions/redocly.yaml
@@ -1,0 +1,10 @@
+extends:
+  - recommended
+
+rules:
+  no-unused-components: off
+  no-empty-servers: off
+
+resolve:
+  file:
+    allowedFileExtensions: [".yaml", ".yml"]


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

This PR introduces a new `/capabilities/devices/{deviceId}` API to support operator device capability discovery. This endpoint allows API consumers to inspect feature support on operator-supplied (CPE) devices, such as support for reboot, Wi-Fi configurations, onboarding protocols (e.g., DPP, Matter), telemetry, and trust domain integration.

The work lays foundational support for Zero-Touch Onboarding (ZTO) integration by enabling dynamic discovery of whether a given operator device can participate in ZTO-style bootstrapping and configuration flows.

The schema is designed to be extensible and future-proof, allowing additional capabilities and client-side support to be introduced over time.

#### Which issue(s) this PR fixes:

Fixes #38 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

- New `capabilities.yaml` spec and supporting reusable components are structured to integrate with the existing NAM API and follow Redocly-compatible bundling practices.
- OperatorDeviceCapabilities and ClientDeviceCapabilities schemas use a `discriminator` model to allow for future expansion.
- Includes reusable parameter `deviceIdParam` and OpenID security requirement.
- Bundled version validated with `redocly lint` and generated via `redocly bundle`.

#### Changelog input

Add device capability discovery endpoint and schemas to support inspection of operator-supplied device features (e.g., onboarding protocols, telemetry, trust domain support).

#### Additional documentation

Bundling with redocly-cli

```
npm install -g @redocly/cli
redocly bundle capabilities.yaml -o bundled-capabilities.yaml
```

