### PR TITLE
Release NAM 0.1.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,53 +2,60 @@
 
 ## Table of Contents
 
-- **[r1.0-rc.1](#r10-rc1)**
+- **[r1.1](#r11)**
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
 
-# r1.0-rc.1
+The below sections record the changes for each API version in each release as follows:
+
+* for an alpha release, the delta with respect to the previous release
+* for the first release-candidate, all changes since the last public release
+* for subsequent release-candidate(s), only the delta to the previous release-candidate
+* for a public release, the consolidated changes since the previous public release
+
+# r1.1
 
 ## Release Notes
 
-This public release contains the definition and documentation of
+This pre-release contains the definition and documentation of
 
 - network-access-management v0.1.0-alpha.1
 
 The API definition(s) are based on
 
-- Commonalities v0.5.0
-- Identity and Consent Management v0.3.0
+- Commonalities r3.4
+- Identity and Consent Management r3.3
 
 ## network-access-management v0.1.0-alpha.1
 
-Version 0.1.0-alpha.1 is in the initial release.
+**network-access-management v0.1.0-alpha.1 is the first alpha release of this API.**
 
 - API definition **with inline documentation**:
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r1.1/code/API_definitions/device-identifier.yaml&nocors)
-  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceIdentifier/r1.1/code/API_definitions/device-identifier.yaml)
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceIdentifier/blob/r1.1/code/API_definitions/device-identifier.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NetworkAccessManagement/r1.1/code/API_definitions/network-access-management.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/NetworkAccessManagement/r1.1/code/API_definitions/network-access-management.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/NetworkAccessManagement/blob/r1.1/code/API_definitions/network-access-management.yaml)
 
 ### Added
 
-- Adds linting by @RandyLevensalor in <https://github.com/camaraproject/NetworkAccessManagement/pull/5>
-- Adds initial API spec YAML by @caubut in <https://github.com/camaraproject/NetworkAccessManagement/pull/7>
-- Adds linting config by @RandyLevensalor in <https://github.com/camaraproject/NetworkAccessManagement/pull/9>
-- Adds linting rules by @RandyLevensalor in <https://github.com/camaraproject/NetworkAccessManagement/pull/11>
+- Initial API definition for managing network operator-supplied network access devices, focused on Trust Domain lifecycle management and Reboot Request management
+- Trust Domain CRUD operations with support for multiple access types: Wi-Fi (WPA Personal, WPA Enterprise) and Thread (Structured, TLV)
+- Trust Domain capabilities discovery endpoint for querying provider-supported configurations
+- Configurable Trust Domain policies: device limits, bandwidth control (upstream/downstream), and egress allowed lists
+- Trust Domain expiration support for ephemeral/time-bounded network configurations
+- Reboot Request CRUD operations with immediate and scheduled execution modes
+- Reboot Request device targeting: explicit (by device UUID) and inferred (default device)
+- Service and Network Access Device read endpoints for subscriber resource enumeration
+- Scope-based authorization model with resource isolation by API client identity
+- Alignment with Commonalities r3.4 error response patterns and `CAMARA_common.yaml` schemas
 
 ### Changed
 
-- Removes family name prefix by @MarkusKuemmerle in <https://github.com/camaraproject/NetworkAccessManagement/pull/6>
-- Updates ICM by @RandyLevensalor in <https://github.com/camaraproject/NetworkAccessManagement/pull/21>
-- Adds @benhepworth as a CODEOWNER by @benhepworth in <https://github.com/camaraproject/NetworkAccessManagement/pull/23>
-- Adds meeting info to `README.md` by @wrathwolf in <https://github.com/camaraproject/NetworkAccessManagement/pull/24>
-- Standardizes errors to follow commonalities by @caubut-charter in <https://github.com/camaraproject/NetworkAccessManagement/pull/30>
-- Commonalities and ICM update by @caubut-charter in <https://github.com/camaraproject/NetworkAccessManagement/pull/32>
+- N/A (first release)
 
 ### Fixed
 
-- Corrects links from initial template in `README.md` by @wrathwolf in <https://github.com/camaraproject/NetworkAccessManagement/pull/1>
-- Corrects mailing list in `README.md` by @caubut-charter in <https://github.com/camaraproject/NetworkAccessManagement/pull/3>
+- N/A (first release)
 
 ### Removed
 
-**Full Changelog**: <https://github.com/camaraproject/DeviceIdentifier/compare/e9235736ee9eb3a6c69f91120d5c6ed41f889d61...r1.0>
+- N/A (first release)

--- a/code/API_definitions/Templates/network-access-management-template.yaml
+++ b/code/API_definitions/Templates/network-access-management-template.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.1.0-alpha.1
   x-camara-commonalities: 0.6
   description: |
     Service enabling API for managing network operator supplied network access devices. This API's initial focus is on
@@ -172,7 +172,7 @@ externalDocs:
   url: https://github.com/camaraproject/NetworkAccessManagement
 
 servers:
-  - url: "{apiRoot}/network-access-management/vwip"
+  - url: "{apiRoot}/network-access-management/v0.1alpha1"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/network-access-management.yaml
+++ b/code/API_definitions/network-access-management.yaml
@@ -4,7 +4,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.1.0-alpha.1
   x-camara-commonalities: 0.6
   description: |
     Service enabling API for managing network operator supplied network access devices. This API's initial focus is on
@@ -166,7 +166,7 @@ info:
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 servers:
-  - url: '{apiRoot}/network-access-management/vwip'
+  - url: '{apiRoot}/network-access-management/v0.1alpha1'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/documentation/API_documentation/network-access-management-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/network-access-management-API-Readiness-Checklist.md
@@ -7,16 +7,16 @@ Checklist for network-access-management 0.1.0-alpha.1 in r1.1.
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [relative link](../../code/API_definitions/network-access-management.yaml)  |
 |  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   | r3.4           |
 |  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   | r3.3          |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |                |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |  0.1.0-alpha.1  |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in yaml |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |   N   |                |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |   Y   | [Trust Domains User Story](../../documentation/API_documentation/TrustDomainsUser_Story.md) - [Device Reboot Request User Story](../../documentation/API_documentation/DeviceRebootRequest_User_Story.md)              |
 |  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   N   |                |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   |                |
 |  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N   |                |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   N   |                |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   N   | [relative link](../../CHANGELOG.md)  |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |   r1.1           |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y   | [relative link](../../CHANGELOG.md)  |
 | 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   N   |                |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |   N   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/81166949/NetworkAccessManagement+API+description) |
+| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |   Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/81166949/NetworkAccessManagement+API+description) |
 
 To fill the checklist:
 


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Prepares the first alpha pre-release (r1.1) of the Network Access Management API as version 0.1.0-alpha.1. This release reflects a significant refactor from the original "Isolated Networks" design to a "Trust Domains" model, addressing the architectural and compliance feedback received during the Fall25 meta-release review (PR #73).

This PR contains only release artifact changes:
- Updated `info.version` from `wip` to `0.1.0-alpha.1` and server URL from `vwip` to `v0.1alpha1`
- Completed `network-access-management-API-Readiness-Checklist.md`
- Updated `CHANGELOG.md` with feature-level release notes

#### Which issue(s) this PR fixes:

Fixes #108 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

**Experimental capabilities spec:** The repository contains an experimental Device Capabilities spec (`code/API_definitions/Templates/network-access-management-template.yaml`) that retains `wip` status and is **not** part of this release. This file was part of an experiment with multi-file bundling strategies that informed [[Commonalities #577](https://github.com/camaraproject/Commonalities/issues/577)](https://github.com/camaraproject/Commonalities/issues/577) (CAMARA_common.yaml consumption and bundling discussion). We welcome guidance on how to handle experimental/WIP specs within the repository structure — whether they should be removed prior to release, relocated, or addressed in a follow-up.

**Not targeting meta-release:** This alpha pre-release is intended for early community feedback and is not targeting inclusion in the Spring '26 meta-release.

**Commonalities alignment:** This release targets alignment with Commonalities r3.4 and ICM r3.3.

#### Changelog input

```release-note
First alpha pre-release of the Network Access Management API (v0.1.0-alpha.1), introducing Trust Domain lifecycle management, Reboot Request management, and supporting Service/Device resource endpoints.
```

#### Additional documentation

```docs
- Release tracker: https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/548798466/Network+Access+Management+v0.1.0
- Fall25 review feedback: PR #73, Issue #77
- Commonalities bundling discussion: https://github.com/camaraproject/Commonalities/issues/577
```