### PR TITLE
110 add zto device registration

### DIFF
--- a/code/API_definitions/modules/NAM_Common.yaml
+++ b/code/API_definitions/modules/NAM_Common.yaml
@@ -24,6 +24,8 @@ components:
         - `network-access-management:trust-domains:read-all` — Read-only access to all Trust Domains
           associated with the same subscriber, including those created by other API clients.
           Intended for use cases involving federated discovery or configuration replication.
+        - `network-access-management:devices` — Register, manage, and deregister subscriber/IoT devices
+          within Trust Domains created by the calling API client.
         - `network-access-management:reboot` — Create, list, and manage Reboot Requests for network
           access devices owned by or delegated to the calling API client.
       openIdConnectUrl: https://example.com/.well-known/openid-configuration

--- a/code/API_definitions/modules/TrustDomainDevices/TrustDomainDevices.yaml
+++ b/code/API_definitions/modules/TrustDomainDevices/TrustDomainDevices.yaml
@@ -1,0 +1,513 @@
+# Local anchor definitions for external component examples. There isn't a native OpenAPI way to
+# cross-reference examples across files, so we define them here for reuse.
+_imported_examples:
+  device-uuid-example: &device-uuid-example "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+  device-uuid-example-2: &device-uuid-example-2 "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"
+  created-by-example: &created-by-example "550e8400-e29b-41d4-a716-446655440000"
+  modified-by-example: &modified-by-example "660e8400-e29b-41d4-a716-446655440000"
+
+  hardware-address-eui48-example: &hardware-address-eui48-example
+    hardwareAddressType: "EUI-48"
+    value: "AA:BB:CC:DD:EE:F1"
+
+  hardware-address-eui48-example-2: &hardware-address-eui48-example-2
+    hardwareAddressType: "EUI-48"
+    value: "AA:BB:CC:DD:EE:F2"
+
+  bootstrapping-dpp-example: &bootstrapping-dpp-example
+    DPP:
+      bootstrappingUri: "DPP:C:81/1;M:aabbccddeeff;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgADURzxmttZoIRIPWGoQMV00XHWCAQIhXruVWOz0NjlkIA=;;"
+
+  bootstrapping-matter-example: &bootstrapping-matter-example
+    MATTER:
+      setupPayload: "MT:Y3.13OTB00KA0648G00"
+
+  bootstrapping-dpp-with-preference-example: &bootstrapping-dpp-with-preference-example
+    protocolPreference:
+      - "DPP"
+    DPP:
+      bootstrappingUri: "DPP:C:81/1;M:aabbccddeeff;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgADURzxmttZoIRIPWGoQMV00XHWCAQIhXruVWOz0NjlkIA=;;"
+
+  device-credential-generate-example: &device-credential-generate-example
+    credentialAction: "GENERATE"
+    supportedTypes:
+      - "WPA3_SAE"
+      - "WPA2_PSK"
+
+  device-credential-assign-example: &device-credential-assign-example
+    credentialAction: "ASSIGN"
+    credentialType: "WPA2_PSK"
+    value: "my-device-passphrase-123"
+
+components:
+
+  parameters:
+    deviceId:
+      name: deviceId
+      in: path
+      required: true
+      schema:
+        $ref: "../NAM_Common.yaml#/components/schemas/UUID"
+      description: |
+        The unique identifier of the Trust Domain Device. If the device exists but the caller
+        lacks permission to access it, the API returns 403.
+
+        Must be a valid UUID as defined by RFC 4122 (versions 1-5) using only lowercase hexadecimal characters.
+
+  schemas:
+
+    DeviceType:
+      type: string
+      description: The category of the device being registered to the Trust Domain.
+      enum:
+        - AUTOMOTIVE
+        - DESKTOP
+        - IOT
+        - LAPTOP
+        - MEDICAL
+        - OTHER
+        - SMARTPHONE
+        - TABLET
+        - TV
+        - WEARABLE
+      example: "IOT"
+
+    BootstrappingProtocol:
+      type: string
+      description: A bootstrapping protocol identifier for device onboarding.
+      enum:
+        - DPP
+        - MATTER
+
+    DppBootstrappingConfig:
+      type: object
+      description: |
+        DPP (Device Provisioning Protocol) bootstrapping configuration as defined
+        by the Wi-Fi Alliance DPP specification.
+      required:
+        - bootstrappingUri
+      properties:
+        bootstrappingUri:
+          type: string
+          maxLength: 2048
+          description: |
+            A DPP bootstrapping URI encoding the device's public key, channel information,
+            and MAC address. Typically presented as a QR code for scanning.
+          example: "DPP:C:81/1;M:aabbccddeeff;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgADURzxmttZoIRIPWGoQMV00XHWCAQIhXruVWOz0NjlkIA=;;"
+
+    MatterBootstrappingConfig:
+      type: object
+      description: |
+        Matter commissioning configuration as defined by the Connectivity Standards
+        Alliance Matter specification.
+      required:
+        - setupPayload
+      properties:
+        setupPayload:
+          type: string
+          maxLength: 2048
+          description: |
+            A Matter setup payload, either as a Manual Pairing Code or QR Code
+            payload, used to commission the device.
+          example: "MT:Y3.13OTB00KA0648G00"
+
+    BootstrappingInfo:
+      type: object
+      description: |
+        Provisioning protocol configurations for onboarding a device to the Trust Domain.
+        Each protocol property (DPP, MATTER) represents a supported bootstrapping protocol
+        and its configuration. A device may support multiple protocols simultaneously.
+
+        When multiple protocols are configured, use `protocolPreference` to indicate the
+        desired selection order. The server selects the first protocol from this list that
+        the Trust Domain's access infrastructure also supports.
+      properties:
+        protocolPreference:
+          type: array
+          items:
+            $ref: "#/components/schemas/BootstrappingProtocol"
+          minItems: 1
+          description: |
+            Bootstrapping protocols in order of preference (most preferred first).
+            The server selects the first protocol compatible with the Trust Domain's
+            access infrastructure. Optional — when omitted, the server selects based
+            on its own policy. Recommended when multiple protocol configurations are
+            provided.
+          example:
+            - "DPP"
+            - "MATTER"
+        selectedProtocol:
+          allOf:
+            - $ref: "#/components/schemas/BootstrappingProtocol"
+            - readOnly: true
+              description: |
+                The bootstrapping protocol selected by the server for onboarding this
+                device. Present only in responses. Determined by intersecting the
+                device's configured protocols with the Trust Domain's capabilities,
+                respecting protocolPreference ordering if provided.
+        DPP:
+          $ref: "#/components/schemas/DppBootstrappingConfig"
+        MATTER:
+          $ref: "#/components/schemas/MatterBootstrappingConfig"
+
+    CredentialType:
+      type: string
+      description: A network credential type for device authentication.
+      enum:
+        - WPA2_PSK
+        - WPA3_SAE
+
+    GenerateDeviceCredential:
+      type: object
+      description: |
+        Request the server to generate a unique per-device credential. The API
+        consumer provides the credential types the device supports, in preference
+        order (most preferred first). The server selects the first type that is
+        compatible with the Trust Domain's access configuration and generates a
+        unique credential of that type. The generated credential is exchanged
+        with the device during bootstrapping (DPP, Matter, etc.).
+      required:
+        - credentialAction
+        - supportedTypes
+      properties:
+        credentialAction:
+          type: string
+          enum:
+            - GENERATE
+          description: Indicates the server should generate a credential.
+          example: "GENERATE"
+        supportedTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/CredentialType"
+          minItems: 1
+          description: |
+            Credential types the device supports, ordered by preference (most
+            preferred first). The server selects the first type compatible with
+            the Trust Domain's access configuration.
+          example:
+            - "WPA3_SAE"
+            - "WPA2_PSK"
+        selectedType:
+          allOf:
+            - $ref: "#/components/schemas/CredentialType"
+            - readOnly: true
+              description: |
+                The credential type the server selected. Present only in responses.
+                Determined by matching supportedTypes against the Trust Domain's
+                access configuration.
+
+    AssignDeviceCredential:
+      type: object
+      description: |
+        Assign a specific credential value to the device. The API consumer
+        provides both the credential type and the passphrase to use.
+      required:
+        - credentialAction
+        - credentialType
+        - value
+      properties:
+        credentialAction:
+          type: string
+          enum:
+            - ASSIGN
+          description: Indicates the client is providing a specific credential.
+          example: "ASSIGN"
+        credentialType:
+          $ref: "#/components/schemas/CredentialType"
+        value:
+          type: string
+          writeOnly: true
+          minLength: 8
+          maxLength: 255
+          description: |
+            The credential value (e.g., passphrase or pre-shared key) to assign.
+            Write-only — never returned in API responses.
+          example: "my-device-passphrase-123"
+
+    DeviceCredential:
+      description: |
+        Per-device network credential configuration. Allows the API consumer to
+        either request server-generated credentials (GENERATE) or assign a
+        specific credential value (ASSIGN).
+
+        If this field is omitted entirely from the device registration, the device
+        uses the Trust Domain's shared credential from accessDetails.
+      oneOf:
+        - $ref: "#/components/schemas/GenerateDeviceCredential"
+        - $ref: "#/components/schemas/AssignDeviceCredential"
+      discriminator:
+        propertyName: credentialAction
+        mapping:
+          GENERATE: "#/components/schemas/GenerateDeviceCredential"
+          ASSIGN: "#/components/schemas/AssignDeviceCredential"
+
+    TrustDomainDeviceUpdate:
+      type: object
+      description: |
+        Represents the updatable fields of a device registered to a Trust Domain.
+        All fields are optional; only the fields included in the request body will be updated.
+      properties:
+        deviceName:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: Human-readable name for the device.
+          example: "Living Room Speaker"
+        deviceType:
+          $ref: "#/components/schemas/DeviceType"
+        enabled:
+          type: boolean
+          description: |
+            Indicates whether the device is enabled. When disabled, the device will not
+            be able to authenticate to the Trust Domain.
+          example: true
+        blocked:
+          type: boolean
+          description: |
+            Indicates whether the device's data forwarding is blocked. When blocked,
+            the device cannot forward data to the Internet or communicate with other
+            devices in the Trust Domain, even if it is enabled and connected.
+          example: false
+        hardwareAddress:
+          type: object
+          description: The hardware address of the device.
+          properties:
+            hardwareAddressType:
+              type: string
+              enum: ["EUI-48"]
+              description: The type of hardware address. Currently only EUI-48 (MAC-48) is supported.
+              example: "EUI-48"
+            value:
+              type: string
+              pattern: "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+              description: The hardware address value in the format specified by hardwareAddressType.
+              example: "AA:BB:CC:DD:EE:F1"
+          required:
+            - hardwareAddressType
+            - value
+        bootstrappingInfo:
+          allOf:
+            - $ref: "#/components/schemas/BootstrappingInfo"
+            - description: |
+                Provisioning protocol configurations that define how this device can be
+                onboarded to the Trust Domain. Each property identifies a bootstrapping
+                protocol and its configuration. A device may support multiple protocols.
+                Use `protocolPreference` to express the device's preferred protocol ordering
+                for deterministic server selection.
+
+                **Update Semantics**
+                - On update (PATCH), the object replaces the previous object entirely when
+                  included. Partial merge semantics are not defined; clients MUST supply the
+                  complete desired configuration for this field.
+        deviceCredential:
+          $ref: "#/components/schemas/DeviceCredential"
+
+    TrustDomainDeviceCreate:
+      allOf:
+        - $ref: "#/components/schemas/TrustDomainDeviceUpdate"
+      description: |
+        Represents the creation payload for registering a new device to a Trust Domain.
+        Extends TrustDomainDeviceUpdate with additional creation-only fields and required field constraints.
+      required:
+        - deviceName
+        - enabled
+      properties:
+        externalId:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: |
+            A manufacturer or user-assigned identifier for the device (e.g., serial number,
+            model code, or asset tag). This is distinct from the system-generated UUID `id`
+            and can be used for cross-referencing the device with external systems.
+          example: "SN-12345-ABCDE"
+
+    TrustDomainDevice:
+      allOf:
+        - $ref: "../NAM_Common.yaml#/components/schemas/ResourceIdentifier"
+        - $ref: "#/components/schemas/TrustDomainDeviceCreate"
+        - $ref: "../../common/CAMARA_common.yaml#/components/schemas/Device"
+        - $ref: "../NAM_Common.yaml#/components/schemas/ResourceAudit"
+        - type: object
+          properties:
+            id:
+              readOnly: true
+            ipv4Address:
+              readOnly: true
+            ipv6Address:
+              readOnly: true
+            createdAt:
+              readOnly: true
+            createdBy:
+              readOnly: true
+            modifiedAt:
+              readOnly: true
+            modifiedBy:
+              readOnly: true
+            connected:
+              type: boolean
+              readOnly: true
+              description: |
+                Indicates whether the device is currently connected to the network.
+                This field is populated by the system and is read-only.
+              example: true
+            associated:
+              type: boolean
+              readOnly: true
+              description: |
+                Indicates whether the device is currently associated with the Trust Domain's
+                network infrastructure. A device may be registered but not yet associated
+                if it has not completed the onboarding process.
+              example: true
+      description: |
+        Represents a device registered to a Trust Domain within the network access management system.
+        This schema represents subscriber or IoT devices that have been provisioned to join a Trust Domain,
+        as opposed to NetworkAccessDevice which represents operator-supplied network access equipment.
+
+        This schema extends the CAMARA Commonalities `Device` model. The inherited `ipv4Address` and
+        `ipv6Address` fields are populated by the system when the device connects and are read-only.
+        The inherited `phoneNumber` and `networkAccessIdentifier` fields are not applicable to
+        Trust Domain Devices and will not be populated.
+
+    TrustDomainDeviceList:
+      type: array
+      description: A list of devices registered to a Trust Domain.
+      items:
+        $ref: "#/components/schemas/TrustDomainDevice"
+
+  examples:
+
+    TrustDomainDeviceCreateIoT:
+      summary: Register an IoT device with DPP bootstrapping and server-generated credential.
+      value:
+        deviceName: "Smart Thermostat"
+        externalId: "SN-THERMO-001"
+        deviceType: "IOT"
+        enabled: true
+        blocked: false
+        hardwareAddress: *hardware-address-eui48-example
+        bootstrappingInfo: *bootstrapping-dpp-with-preference-example
+        deviceCredential: *device-credential-generate-example
+
+    TrustDomainDeviceCreateMinimal:
+      summary: Register a device with minimal required fields.
+      value:
+        deviceName: "Guest Laptop"
+        enabled: true
+
+    TrustDomainDeviceCreateMatter:
+      summary: Register a Matter device.
+      value:
+        deviceName: "Smart Light Bulb"
+        externalId: "MATTER-BULB-42"
+        deviceType: "IOT"
+        enabled: true
+        blocked: false
+        bootstrappingInfo: *bootstrapping-matter-example
+
+    TrustDomainDeviceCreateAssignCredential:
+      summary: Register a device with a client-provided credential.
+      value:
+        deviceName: "Office Switch"
+        externalId: "SW-OFFICE-01"
+        deviceType: "IOT"
+        enabled: true
+        blocked: false
+        hardwareAddress: *hardware-address-eui48-example
+        bootstrappingInfo: *bootstrapping-dpp-example
+        deviceCredential: *device-credential-assign-example
+
+    TrustDomainDeviceResponseBasic:
+      summary: Basic device response
+      description: Example of a registered Trust Domain Device with server-generated credential.
+      value:
+        id: *device-uuid-example
+        deviceName: "Smart Thermostat"
+        externalId: "SN-THERMO-001"
+        deviceType: "IOT"
+        enabled: true
+        blocked: false
+        hardwareAddress: *hardware-address-eui48-example
+        bootstrappingInfo:
+          protocolPreference:
+            - "DPP"
+          selectedProtocol: "DPP"
+          DPP:
+            bootstrappingUri: "DPP:C:81/1;M:aabbccddeeff;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgADURzxmttZoIRIPWGoQMV00XHWCAQIhXruVWOz0NjlkIA=;;"
+        deviceCredential:
+          credentialAction: "GENERATE"
+          supportedTypes:
+            - "WPA3_SAE"
+            - "WPA2_PSK"
+          selectedType: "WPA2_PSK"
+        connected: false
+        associated: false
+        createdAt: "2025-11-15T10:30:00.000Z"
+        createdBy: *created-by-example
+        modifiedAt: "2025-11-15T10:30:00.000Z"
+        modifiedBy: *created-by-example
+
+    TrustDomainDeviceResponseConnected:
+      summary: Connected device response
+      description: Example of a registered Trust Domain Device that is connected and associated.
+      value:
+        id: *device-uuid-example
+        deviceName: "Smart Thermostat"
+        externalId: "SN-THERMO-001"
+        deviceType: "IOT"
+        enabled: true
+        blocked: false
+        hardwareAddress: *hardware-address-eui48-example
+        bootstrappingInfo:
+          protocolPreference:
+            - "DPP"
+          selectedProtocol: "DPP"
+          DPP:
+            bootstrappingUri: "DPP:C:81/1;M:aabbccddeeff;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgADURzxmttZoIRIPWGoQMV00XHWCAQIhXruVWOz0NjlkIA=;;"
+        deviceCredential:
+          credentialAction: "GENERATE"
+          supportedTypes:
+            - "WPA3_SAE"
+            - "WPA2_PSK"
+          selectedType: "WPA2_PSK"
+        ipv4Address:
+          publicAddress: "192.168.1.100"
+          privateAddress: "192.168.1.100"
+        ipv6Address: "fe80::aabb:ccdd:eef1"
+        connected: true
+        associated: true
+        createdAt: "2025-11-15T10:30:00.000Z"
+        createdBy: *created-by-example
+        modifiedAt: "2025-11-15T12:00:00.000Z"
+        modifiedBy: *modified-by-example
+
+    TrustDomainDeviceListResponse:
+      summary: List of registered devices
+      description: Example response for listing all devices in a Trust Domain.
+      value:
+        - id: *device-uuid-example
+          deviceName: "Smart Thermostat"
+          externalId: "SN-THERMO-001"
+          deviceType: "IOT"
+          enabled: true
+          blocked: false
+          hardwareAddress: *hardware-address-eui48-example
+          connected: true
+          associated: true
+          createdAt: "2025-11-15T10:30:00.000Z"
+          createdBy: *created-by-example
+          modifiedAt: "2025-11-15T10:30:00.000Z"
+          modifiedBy: *created-by-example
+        - id: *device-uuid-example-2
+          deviceName: "Guest Laptop"
+          deviceType: "LAPTOP"
+          enabled: true
+          blocked: false
+          hardwareAddress: *hardware-address-eui48-example-2
+          connected: false
+          associated: false
+          createdAt: "2025-11-16T08:00:00.000Z"
+          createdBy: *created-by-example
+          modifiedAt: "2025-11-16T08:00:00.000Z"
+          modifiedBy: *created-by-example

--- a/code/API_definitions/modules/TrustDomainDevices/TrustDomainDevices.yaml
+++ b/code/API_definitions/modules/TrustDomainDevices/TrustDomainDevices.yaml
@@ -99,7 +99,10 @@ components:
       type: object
       description: |
         Matter commissioning configuration as defined by the Connectivity Standards
-        Alliance Matter specification.
+        Alliance (CSA) Matter specification (Section 5.1.3 - Onboarding Payload).
+      externalDocs:
+        description: Matter Specification - Connectivity Standards Alliance
+        url: https://csa-iot.org/developer-resource/specifications-download-request/
       required:
         - setupPayload
       properties:
@@ -107,8 +110,18 @@ components:
           type: string
           maxLength: 2048
           description: |
-            A Matter setup payload, either as a Manual Pairing Code or QR Code
-            payload, used to commission the device.
+            A Matter onboarding payload used to commission the device. Accepts either format:
+
+            - **QR Code Payload**: Prefixed with `MT:`, followed by a base-38 encoded string
+              (characters `0-9`, `A-Z`, `-.`) encoding the device's vendor ID, product ID,
+              discriminator, setup passcode, and discovery capabilities.
+              Example: `MT:Y3.13OTB00KA0648G00`
+
+            - **Manual Pairing Code**: A numeric string (typically 11 or 21 digits) encoding
+              a subset of the same commissioning data for manual entry.
+              Example: `34970112332`
+
+            See Matter Core Specification Section 5.1.3 for payload structure details.
           example: "MT:Y3.13OTB00KA0648G00"
 
     BootstrappingInfo:

--- a/code/API_definitions/network-access-management.yaml
+++ b/code/API_definitions/network-access-management.yaml
@@ -709,8 +709,6 @@ paths:
             application/json:
               schema:
                 $ref: "modules/NetworkAccessDevices/NetworkAccessDevices.yaml#/components/schemas/NetworkAccessDeviceList"
-        "400":
-          $ref: "common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -742,8 +740,6 @@ paths:
             application/json:
               schema:
                 $ref: "modules/NetworkAccessDevices/NetworkAccessDevices.yaml#/components/schemas/NetworkAccessDevice"
-        "400":
-          $ref: "common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -852,8 +848,6 @@ paths:
                 type: array
                 items:
                   $ref: 'modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
-        '400':
-          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -884,8 +878,6 @@ paths:
             application/json:
               schema:
                 $ref: 'modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
-        '400':
-          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -950,8 +942,6 @@ paths:
       responses:
         '204':
           description: Reboot Request deleted successfully
-        '400':
-          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':

--- a/code/API_definitions/network-access-management.yaml
+++ b/code/API_definitions/network-access-management.yaml
@@ -225,6 +225,8 @@ paths:
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "500":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic500"
+        "503":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic503"
 
 
   /services/{serviceId}:
@@ -270,6 +272,8 @@ paths:
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic404"
         "500":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic500"
+        "503":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic503"
 
   /trust-domains/capabilities:
     get:
@@ -300,6 +304,8 @@ paths:
             application/json:
               schema:
                 $ref: "modules/TrustDomains/TrustDomainCapabilities.yaml#/components/schemas/TrustDomainCapabilities"
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "500":
@@ -351,12 +357,16 @@ paths:
                   $ref: 'modules/TrustDomains/TrustDomains.yaml#/components/examples/TrustDomainResponseWiFiThread'
         '400':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
         '409':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic409'
         '500':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
     get:
       tags:
@@ -384,6 +394,8 @@ paths:
                 type: array
                 items:
                   $ref: "modules/TrustDomains/TrustDomains.yaml#/components/schemas/TrustDomain"
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "500":
@@ -421,6 +433,8 @@ paths:
               examples:
                 TrustDomainResponseBasic:
                   $ref: 'modules/TrustDomains/TrustDomains.yaml#/components/examples/TrustDomainResponseBasic'
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
@@ -457,6 +471,8 @@ paths:
 
         "400":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic400"
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
@@ -480,6 +496,8 @@ paths:
       responses:
         "204":
           description: Trust Domain deleted successfully
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
@@ -693,6 +711,8 @@ paths:
                 $ref: "modules/NetworkAccessDevices/NetworkAccessDevices.yaml#/components/schemas/NetworkAccessDeviceList"
         "400":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic400"
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
@@ -724,6 +744,8 @@ paths:
                 $ref: "modules/NetworkAccessDevices/NetworkAccessDevices.yaml#/components/schemas/NetworkAccessDevice"
         "400":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic400"
+        "401":
+          $ref: "common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic403"
         "404":
@@ -796,6 +818,8 @@ paths:
                 $ref: 'modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
         '400':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
         '404':
@@ -806,6 +830,8 @@ paths:
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic422'
         '500':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
     get:
       tags:
@@ -828,10 +854,14 @@ paths:
                   $ref: 'modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
         '400':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
         '500':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
   /reboot-requests/{rebootRequestId}:
     parameters:
@@ -856,12 +886,16 @@ paths:
                 $ref: 'modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
         '400':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
         '404':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
         '500':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
     patch:
       tags:
@@ -888,6 +922,8 @@ paths:
                 $ref: 'modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
         '400':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
         '404':
@@ -898,6 +934,8 @@ paths:
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic422'
         '500':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
     delete:
       tags:
@@ -914,12 +952,16 @@ paths:
           description: Reboot Request deleted successfully
         '400':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
         '404':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
         '500':
           $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
 components:
   securitySchemes:

--- a/code/API_definitions/network-access-management.yaml
+++ b/code/API_definitions/network-access-management.yaml
@@ -76,6 +76,7 @@ info:
     |-------|-------------|
     | **network-access-management:trust-domains** | Manage the caller's own Trust Domains (create, modify, delete, view). |
     | **network-access-management:trust-domains:read-all** | Read all Trust Domains belonging to the subscriber, including those created by other clients (requires subscriber consent). |
+    | **network-access-management:devices** | Register, manage, and deregister subscriber/IoT devices within Trust Domains created by the calling API client. |
     | **network-access-management:reboot** | Create, list, and manage Reboot Requests for owned devices. |
     | **network-access-management:services:read** | List services accessible to the authenticated identity |
 
@@ -183,6 +184,10 @@ tags:
     description: Operations to list network services accessible to the authenticated identity
   - name: Trust Domains
     description: Operations to Create and Manage Trust Domains
+  - name: Trust Domain Devices
+    description: |
+      Operations to register and manage subscriber/IoT devices within Trust Domains.
+      These devices are distinct from Network Access Devices (operator-supplied equipment).
   - name: Reboot Requests
     description: |
       Operations to Create and Manage Reboot Requests for Network Access Devices
@@ -483,6 +488,190 @@ paths:
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic500"
         "503":
           $ref: "common/CAMARA_common.yaml#/components/responses/Generic503"
+
+  /trust-domains/{trustDomainId}/devices:
+    parameters:
+      - $ref: 'modules/TrustDomains/TrustDomains.yaml#/components/parameters/trustDomainId'
+
+    post:
+      tags:
+        - Trust Domain Devices
+      summary: Register a new device to a Trust Domain
+      security:
+        - openId:
+            - network-access-management:devices
+      description: |
+        Registers a new subscriber or IoT device to the specified Trust Domain.
+        The device will be provisioned for network access according to the Trust Domain's
+        access configuration and the device's bootstrapping and credential settings.
+      operationId: createTrustDomainDevice
+      requestBody:
+        description: Details of the device to register
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/schemas/TrustDomainDeviceCreate'
+            examples:
+              TrustDomainDeviceCreateIoT:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceCreateIoT'
+              TrustDomainDeviceCreateMinimal:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceCreateMinimal'
+              TrustDomainDeviceCreateMatter:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceCreateMatter'
+      responses:
+        '201':
+          description: Device registered successfully
+          content:
+            application/json:
+              schema:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/schemas/TrustDomainDevice'
+              examples:
+                TrustDomainDeviceResponseBasic:
+                  $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceResponseBasic'
+        '400':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
+        '403':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
+        '404':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
+        '409':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic409'
+        '500':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
+
+    get:
+      tags:
+        - Trust Domain Devices
+      summary: List all devices registered to a Trust Domain
+      security:
+        - openId:
+            - network-access-management:devices
+      operationId: getTrustDomainDevices
+      description: |
+        Retrieves all devices registered to the specified Trust Domain that the caller is authorized to view.
+      responses:
+        '200':
+          description: Contains the list of registered devices
+          content:
+            application/json:
+              schema:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/schemas/TrustDomainDeviceList'
+              examples:
+                TrustDomainDeviceListResponse:
+                  $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceListResponse'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
+        '403':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
+        '404':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
+        '500':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
+
+  /trust-domains/{trustDomainId}/devices/{deviceId}:
+    parameters:
+      - $ref: 'modules/TrustDomains/TrustDomains.yaml#/components/parameters/trustDomainId'
+      - $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/parameters/deviceId'
+
+    get:
+      tags:
+        - Trust Domain Devices
+      summary: Get a specific device in a Trust Domain
+      security:
+        - openId:
+            - network-access-management:devices
+      operationId: getTrustDomainDevice
+      description: |
+        Retrieves the device identified by the given ID within the specified Trust Domain.
+      responses:
+        '200':
+          description: Contains information about the specified device
+          content:
+            application/json:
+              schema:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/schemas/TrustDomainDevice'
+              examples:
+                TrustDomainDeviceResponseConnected:
+                  $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceResponseConnected'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
+        '403':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
+        '404':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
+        '500':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
+
+    patch:
+      tags:
+        - Trust Domain Devices
+      summary: Update a device in a Trust Domain
+      security:
+        - openId:
+            - network-access-management:devices
+      operationId: updateTrustDomainDevice
+      description: |
+        Updates the device identified by the given ID within the specified Trust Domain.
+        Only the fields included in the request body will be updated. The `bootstrappingInfo`
+        and `deviceCredential` fields use full replacement semantics when included.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/schemas/TrustDomainDeviceUpdate'
+        required: true
+      responses:
+        '200':
+          description: Device updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: 'modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/schemas/TrustDomainDevice'
+        '400':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic400'
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
+        '403':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
+        '404':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
+        '500':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
+
+    delete:
+      tags:
+        - Trust Domain Devices
+      summary: Remove a device from a Trust Domain
+      security:
+        - openId:
+            - network-access-management:devices
+      operationId: deleteTrustDomainDevice
+      description: |
+        Deregisters and removes the device identified by the given ID from the specified Trust Domain.
+      responses:
+        '204':
+          description: Device removed successfully
+        '401':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic401'
+        '403':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic403'
+        '404':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic404'
+        '500':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic500'
+        '503':
+          $ref: 'common/CAMARA_common.yaml#/components/responses/Generic503'
 
   /network-access-devices:
     get:


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds Trust Domain Device registration endpoints to the Network Access Management API, enabling zero-touch onboarding (ZTO) of subscriber and IoT devices to Trust Domains.

This introduces 5 new endpoints under `/trust-domains/{trustDomainId}/devices` for full CRUD lifecycle management of devices within a Trust Domain, including support for multiple bootstrapping protocols (DPP, Matter) and flexible credential management (server-generated or client-assigned).

Also includes consistency fixes to error responses across all existing endpoints (uniform 401/503, removal of unnecessary 400 on read-only endpoints).

#### Which issue(s) this PR fixes:

Fixes #110

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

This branch was rebased onto main after the #115 directory restructuring (Domain/ → modules/, Templates/ eliminated, bundled output no longer committed). The feature content is equivalent to what was previously on this branch, adapted to the new modular layout.

**New files:**
- `modules/TrustDomainDevices/TrustDomainDevices.yaml` — all device registration schemas, parameters, and examples

**Modified files:**
- `network-access-management.yaml` — 5 new endpoints, new "Trust Domain Devices" tag, new `network-access-management:devices` scope in description
- `modules/NAM_Common.yaml` — added `network-access-management:devices` scope to OpenID security scheme

**Error response consistency fixes (all endpoints):**
- Added `401 Unauthorized` to all endpoints that were missing it
- Added `503 Service Unavailable` to all endpoints that were missing it
- Removed `400 Bad Request` from GET/DELETE endpoints that don't accept input beyond path parameters

**Verification:**
- `redocly lint` passes with zero errors
- `redocly bundle` produces valid standalone output

#### Changelog input

```
release-note
Add Trust Domain Device registration endpoints for zero-touch onboarding (DPP, Matter). Uniform 401/503 error responses across all endpoints.
```