### PR TITLE
52 create gherkin feature file

### DIFF
--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -18,7 +18,7 @@ and the reusable templates in
 |---|---|
 | Filename | `network-access-management-{operationId}.feature` (one file per `operationId`) |
 | Scenario tag | `@network_access_management_{operationId}_{NN}_{slug}` |
-| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Three placements depending on file shape: (a) **multi-scenario, single tier** → Feature level only, with each scenario carrying just its unique id tag; (b) **multi-scenario, mixed tiers** (like the pilot) → on each individual scenario alongside its unique id; (c) **single-scenario** → at *both* Feature and Scenario level. The single-scenario case is forced by the simultaneous `gherkin-lint` rules `no-homogenous-tags` (factor shared tags up to Feature) and `required-tags` (every Scenario must carry ≥1 tag). |
+| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placement depends on file shape: (a) **multi-scenario, single tier** → both `@basic_tier` and the unique scenario-id tag at Feature level only, scenarios carry no tags of their own; (b) **multi-scenario, mixed tiers** (like the pilot) → tier tag on each individual scenario alongside its unique id; (c) **single-scenario** → both tags at Feature level only (do not duplicate at the Scenario — that fires `no-superfluous-tags`). The interacting `gherkin-lint` rules to keep in mind: `no-homogenous-tags`, `required-tags`, `no-superfluous-tags`, `indentation`. Run `gherkin-lint` locally before pushing — see "Executing the tests" below. |
 | Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; skip when running against a facade in auth-disabled mode |
 | Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. 409 conflicts) |
 | Setup steps | For files with **2+ scenarios**, factored into a `Background:` block (`apiRoot` + resource + `Authorization` with required scope + `x-correlator` schema check, plus `Content-Type` and a default-valid request body for write ops). For files with a **single scenario**, inlined directly into the scenario — `Background:` is disallowed by `gherkin-lint`'s `no-background-only-scenario`. |
@@ -89,23 +89,28 @@ When adding a new file:
    for the multi-scenario / mixed-tier shape, or from any of the GET-by-id
    files (e.g. `network-access-management-getService.feature`) for the
    single-scenario shape with inlined setup steps.
-2. Decide where the tier tag goes based on the file's contents. Three
-   `gherkin-lint` rules interact here (`no-homogenous-tags`,
-   `required-tags`, and `indentation` requiring 2-space indent for tags):
+2. Decide where the tier tag goes based on the file's contents. Four
+   interacting `gherkin-lint` rules apply: `no-homogenous-tags`,
+   `required-tags`, `no-superfluous-tags`, and `indentation` (2-space
+   indent for tags).
    - **Multi-scenario, all the same tier** → put `@basic_tier` (or
      `@full_tier`) on its own line above `Feature:` (2-space indent).
      Each scenario keeps just its unique id tag — that satisfies
-     `required-tags`, and no two scenarios share scenario-level tags so
-     `no-homogenous-tags` is silent.
+     `required-tags`, no two scenarios share scenario-level tags so
+     `no-homogenous-tags` is silent, and no tag is duplicated across
+     levels so `no-superfluous-tags` is silent.
    - **Multi-scenario, mixed tiers** (like the pilot, where some
      scenarios are basic and others are full) → keep the tier tag on
      each individual scenario alongside its unique id.
-   - **Single-scenario file** → put the tag set at **both** Feature
-     level *and* Scenario level. `no-homogenous-tags` is satisfied
-     because the tags exist at Feature level; `required-tags` is
-     satisfied because the Scenario has its own tag line. Yes, this
-     duplicates the tags. Yes, both rules are simultaneously demanding
-     it. Don't try to remove either copy without re-running CI.
+   - **Single-scenario file** → put both `@basic_tier` and the unique
+     scenario id at Feature level (combined on one line, 2-space
+     indent). Do **not** repeat them above the Scenario — that fires
+     `no-superfluous-tags`. Note: this configuration depends on the
+     centralized CAMARA gherkin-lint config not enforcing
+     `required-tags` strictly on Scenario lines that inherit Feature
+     tags. **Always validate locally** with `gherkin-lint` before
+     pushing to avoid the rule-interaction surprises this PR
+     repeatedly hit (see "Executing the tests" for the recipe).
 3. Decide whether to use a `Background:` block:
    - 2+ scenarios → factor common setup into a `Background:`.
    - Exactly 1 scenario → inline the setup steps directly into that

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -18,9 +18,9 @@ and the reusable templates in
 |---|---|
 | Filename | `network-access-management-{operationId}.feature` (one file per `operationId`) |
 | Scenario tag | `@network_access_management_{operationId}_{NN}_{slug}` |
-| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placement: (a) **multi-scenario, single tier** → at Feature level (above `Feature:`, 2-space indent), with each scenario carrying just its unique id tag; (b) **multi-scenario, mixed tiers** (the pilot and every Group B file in this repo, which mix one `@basic_tier` happy path with one `@full_tier @requires_oidc` 401 scenario) → tier tag on each individual scenario alongside its unique id; no Feature-level tier tag. The four interacting `gherkin-lint` rules: `no-homogenous-tags` (scenarios may not all share a tag at scenario level), `required-tags` (every Scenario must have ≥1 tag), `no-superfluous-tags` (no tag duplicated across Feature and Scenario), `indentation` (2-space indent for tags). |
+| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placement depends on tier homogeneity within the file: if every scenario shares the same tier, put the tier tag once at Feature level (2-space indent, on the line above `Feature:`); if the file mixes tiers, drop the Feature-level tier tag and put the appropriate tier tag on each scenario alongside its unique id. The "Local lint" section below lists the underlying `gherkin-lint` rules this placement satisfies. |
 | Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; auto-skip when running against a facade in auth-disabled mode |
-| Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. 409 conflicts) |
+| Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. a 409 conflict where a duplicate must already exist on the server). Used sparingly: tag a scenario only when its setup truly requires backend cooperation a runner cannot simulate via client-side requests. |
 | Setup steps | Always factored into a `Background:` block (`apiRoot` + resource + `Authorization` with required scope + `x-correlator` schema check, plus `Content-Type` and a default-valid request body for write ops, plus any path parameters shared across all scenarios). Every file in this directory has at least 2 scenarios — single-scenario files cannot satisfy the lint rule trio above, which is why Group B GETs each carry a 401 `@requires_oidc` scenario alongside the happy path. |
 | Schema references | JSON Pointer into the **bundled** OAS (e.g. `/components/schemas/TrustDomain`), not into `modules/...` |
 | Error-code coverage | One named `Scenario:` per documented response code; `Scenario Outline:` for parameter-varied cases (e.g. each missing-required-field permutation) |
@@ -40,15 +40,22 @@ Per the CAMARA API Testing Guidelines:
 **full tier** as the canonical exemplar — happy paths plus the full
 400/401/403/409 error matrix.
 
-The other 19 operations are authored at **basic tier** for sunny-day
-coverage. The 9 single-resource GETs additionally include a `401`
-unauthenticated scenario (tagged `@full_tier @requires_oidc`) — added to
-satisfy the `gherkin-lint` rule trio that rejects single-scenario files,
-and serves as the seed for further full-tier expansion. Group A
-multi-scenario files (Trust Domain CRUD, Trust Domain Device CRUD,
-Reboot Request CRUD) remain basic-tier-only for now; their full-tier
-rainy-day matrices are tracked as a follow-up workstream against the
-public-release readiness gate; see
+The remaining 19 operations are authored at **basic tier** for sunny-day
+coverage, and split into two structural groups:
+
+- **Group A** — multi-scenario CRUD files (Trust Domain CRUD, Trust
+  Domain Device CRUD, Reboot Request CRUD). Every scenario is
+  basic-tier, so a single Feature-level `@basic_tier` tag covers all
+  scenarios in the file.
+- **Group B** — the 9 single-resource GETs. Each carries a basic-tier
+  happy-path scenario plus a `401` unauthenticated scenario tagged
+  `@full_tier @requires_oidc`. The 401 scenario seeds the eventual
+  full-tier expansion and also satisfies the `gherkin-lint` rule trio
+  that rejects single-scenario files. Because the file mixes tiers,
+  tier tags live on each scenario rather than at Feature level.
+
+Group A's full-tier rainy-day matrices are tracked as a follow-up
+workstream against the public-release readiness gate; see
 [issue #52](https://github.com/camaraproject/NetworkAccessManagement/issues/52).
 
 ## File inventory

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -1,1 +1,95 @@
-This directory contains at least one `.feature` file containing test definitions for the repository API(s).
+# Network Access Management — Test Definitions
+
+This directory contains Gherkin (`.feature`) test definitions for the
+Network Access Management API. The files describe the behavioral contract
+of each operation: happy paths, schema validation, and the documented
+error cases. They are runner-agnostic by design — see "Executing the tests"
+below.
+
+These tests are produced and graded against the
+[CAMARA API Testing Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-Testing-Guidelines.md)
+and the reusable templates in
+[`Commonalities/artifacts/testing/`](https://github.com/camaraproject/Commonalities/tree/main/artifacts/testing)
+(`syntax-errors-template.feature`, `C01-device-errors.feature`, etc.).
+
+## Conventions
+
+| Convention | Value |
+|---|---|
+| Filename | `network-access-management-{operationId}.feature` (one file per `operationId`) |
+| Scenario tag | `@network_access_management_{operationId}_{NN}_{slug}` |
+| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate) |
+| Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; skip when running against a facade in auth-disabled mode |
+| Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. 409 conflicts) |
+| `Background` block | `apiRoot` + resource + `Content-Type` + `Authorization` (with required scope) + `x-correlator` schema check + default-valid request body |
+| Schema references | JSON Pointer into the **bundled** OAS (e.g. `/components/schemas/TrustDomain`), not into `modules/...` |
+| Error-code coverage | One named `Scenario:` per documented response code; `Scenario Outline:` for parameter-varied cases (e.g. each missing-required-field permutation) |
+
+## Coverage tiers
+
+Per the CAMARA API Testing Guidelines:
+
+- **Basic test plan** (mandatory at release-candidate): sunny-day scenarios
+  for every operation plus mandatory request/response schema validation.
+- **Full test plan** (mandatory at initial public release): basic, plus one
+  scenario per documented error status, auth edge cases, semantic
+  validation, optional-field combinations, and CRUD state coherence
+  (GET-after-POST agreement).
+
+The current pilot file (`network-access-management-createTrustDomain.feature`)
+is authored at the full tier as the canonical exemplar. Subsequent files in
+this directory will be added at basic tier first, then expanded.
+
+## File inventory
+
+The full target inventory is one `.feature` per operationId (20 files
+total). At present, only the pilot is committed; the rest are tracked in
+[issue #52](https://github.com/camaraproject/NetworkAccessManagement/issues/52).
+
+| Tag group | Operations |
+|---|---|
+| Services | `getServices`, `getService` |
+| Trust Domains | `getTrustDomainCapabilities`, `createTrustDomain`*, `getTrustDomains`, `getTrustDomain`, `updateTrustDomain`, `deleteTrustDomain` |
+| Trust Domain Devices | `createTrustDomainDevice`, `getTrustDomainDevices`, `getTrustDomainDevice`, `updateTrustDomainDevice`, `deleteTrustDomainDevice` |
+| Network Access Devices | `getNetworkAccessDevices`, `getNetworkAccessDevice` |
+| Reboot Requests | `createRebootRequest`, `getRebootRequests`, `getRebootRequest`, `updateRebootRequest`, `deleteRebootRequest` |
+
+`*` = pilot, full-tier exemplar already committed.
+
+## Executing the tests
+
+CAMARA does not standardize a test runner. The step phrases used in these
+files are runner-agnostic — they reference the OAS by `operationId` and
+JSON Pointer rather than by literal HTTP details — so a runner needs to:
+
+1. Load the **bundled** OAS (`redocly bundle network-access-management.yaml
+   --output network-access-management-bundled.yaml` from
+   `code/API_definitions/`) and index `operationId → (method, path, schemas)`.
+2. Set `apiRoot` from the target environment.
+3. Acquire a token compatible with the scope listed in each operation's
+   `security: openId: [...]` block. The test runner is expected to support
+   running against an OIDC server (Keycloak, `navikt/mock-oauth2-server`,
+   etc.) or a facade dev mode that bypasses token validation.
+4. Echo `x-correlator` per request and assert strict equality on response.
+5. Validate response bodies against the schema reference cited in the
+   `Then ... complies with the OAS schema at ...` step.
+
+Examples of compatible runner stacks: Behave + `requests` + `openapi-core`
+(Python), Cucumber-JS + Apickli, Karate. The runner harness is **not**
+committed to this repository — it is environment-specific and lives in
+the consuming organization's test infrastructure.
+
+## Authoring guidance
+
+When adding a new file:
+
+1. Start from the pilot (`network-access-management-createTrustDomain.feature`)
+   and adapt the `Background` and scenario structure.
+2. For request-body operations, adapt scenarios from
+   [`syntax-errors-template.feature`](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/syntax-errors-template.feature).
+3. Confirm every documented error status in the OAS has at least one
+   scenario.
+4. Run a Gherkin syntax check before committing:
+   `npx @cucumber/gherkin-utils format <file>`.
+5. Tag scope-/auth-dependent scenarios with `@requires_oidc` so they are
+   automatically skipped in environments without an OIDC server.

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -18,10 +18,10 @@ and the reusable templates in
 |---|---|
 | Filename | `network-access-management-{operationId}.feature` (one file per `operationId`) |
 | Scenario tag | `@network_access_management_{operationId}_{NN}_{slug}` |
-| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate) |
+| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placed at **Feature** level when every scenario in the file shares the tag (per `gherkin-lint`'s `no-homogenous-tags`); placed on individual **Scenarios** when the file mixes tiers — see the pilot for that pattern. |
 | Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; skip when running against a facade in auth-disabled mode |
 | Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. 409 conflicts) |
-| `Background` block | `apiRoot` + resource + `Content-Type` + `Authorization` (with required scope) + `x-correlator` schema check + default-valid request body |
+| Setup steps | For files with **2+ scenarios**, factored into a `Background:` block (`apiRoot` + resource + `Authorization` with required scope + `x-correlator` schema check, plus `Content-Type` and a default-valid request body for write ops). For files with a **single scenario**, inlined directly into the scenario — `Background:` is disallowed by `gherkin-lint`'s `no-background-only-scenario`. |
 | Schema references | JSON Pointer into the **bundled** OAS (e.g. `/components/schemas/TrustDomain`), not into `modules/...` |
 | Error-code coverage | One named `Scenario:` per documented response code; `Scenario Outline:` for parameter-varied cases (e.g. each missing-required-field permutation) |
 
@@ -86,12 +86,28 @@ the consuming organization's test infrastructure.
 When adding a new file:
 
 1. Start from the pilot (`network-access-management-createTrustDomain.feature`)
-   and adapt the `Background` and scenario structure.
-2. For request-body operations, adapt scenarios from
+   for the multi-scenario / mixed-tier shape, or from any of the GET-by-id
+   files (e.g. `network-access-management-getService.feature`) for the
+   single-scenario shape with inlined setup steps.
+2. Decide where the tier tag goes based on the file's contents:
+   - All scenarios at the same tier → put `@basic_tier` (or `@full_tier`)
+     on its own line above `Feature:`. Do **not** repeat the tag on every
+     scenario — `gherkin-lint`'s `no-homogenous-tags` will reject it.
+   - Mixed tiers (like the pilot, where some scenarios are basic and
+     others are full) → keep the tag on each individual scenario.
+3. Decide whether to use a `Background:` block:
+   - 2+ scenarios → factor common setup into a `Background:`.
+   - Exactly 1 scenario → inline the setup steps directly into that
+     scenario; `gherkin-lint`'s `no-background-only-scenario` rejects a
+     `Background:` with only one consumer.
+4. For request-body operations, adapt scenarios from
    [`syntax-errors-template.feature`](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/syntax-errors-template.feature).
-3. Confirm every documented error status in the OAS has at least one
-   scenario.
-4. Run a Gherkin syntax check before committing:
-   `npx @cucumber/gherkin-utils format <file>`.
-5. Tag scope-/auth-dependent scenarios with `@requires_oidc` so they are
+5. For full-tier expansion, confirm every documented error status in the
+   OAS has at least one scenario.
+6. Run the Gherkin syntax check before committing:
+   `npx @cucumber/gherkin-utils format <file>`. The MegaLinter job in CI
+   additionally runs `gherkin-lint`; the rules called out above
+   (`no-homogenous-tags`, `no-background-only-scenario`) are the ones
+   that have caught past PRs.
+7. Tag scope-/auth-dependent scenarios with `@requires_oidc` so they are
    automatically skipped in environments without an OIDC server.

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -18,7 +18,7 @@ and the reusable templates in
 |---|---|
 | Filename | `network-access-management-{operationId}.feature` (one file per `operationId`) |
 | Scenario tag | `@network_access_management_{operationId}_{NN}_{slug}` |
-| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placed at **Feature** level when every scenario in the file shares the tag (per `gherkin-lint`'s `no-homogenous-tags`); placed on individual **Scenarios** when the file mixes tiers — see the pilot for that pattern. |
+| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Three placements depending on file shape: (a) **multi-scenario, single tier** → Feature level only, with each scenario carrying just its unique id tag; (b) **multi-scenario, mixed tiers** (like the pilot) → on each individual scenario alongside its unique id; (c) **single-scenario** → at *both* Feature and Scenario level. The single-scenario case is forced by the simultaneous `gherkin-lint` rules `no-homogenous-tags` (factor shared tags up to Feature) and `required-tags` (every Scenario must carry ≥1 tag). |
 | Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; skip when running against a facade in auth-disabled mode |
 | Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. 409 conflicts) |
 | Setup steps | For files with **2+ scenarios**, factored into a `Background:` block (`apiRoot` + resource + `Authorization` with required scope + `x-correlator` schema check, plus `Content-Type` and a default-valid request body for write ops). For files with a **single scenario**, inlined directly into the scenario — `Background:` is disallowed by `gherkin-lint`'s `no-background-only-scenario`. |
@@ -89,12 +89,23 @@ When adding a new file:
    for the multi-scenario / mixed-tier shape, or from any of the GET-by-id
    files (e.g. `network-access-management-getService.feature`) for the
    single-scenario shape with inlined setup steps.
-2. Decide where the tier tag goes based on the file's contents:
-   - All scenarios at the same tier → put `@basic_tier` (or `@full_tier`)
-     on its own line above `Feature:`. Do **not** repeat the tag on every
-     scenario — `gherkin-lint`'s `no-homogenous-tags` will reject it.
-   - Mixed tiers (like the pilot, where some scenarios are basic and
-     others are full) → keep the tag on each individual scenario.
+2. Decide where the tier tag goes based on the file's contents. Three
+   `gherkin-lint` rules interact here (`no-homogenous-tags`,
+   `required-tags`, and `indentation` requiring 2-space indent for tags):
+   - **Multi-scenario, all the same tier** → put `@basic_tier` (or
+     `@full_tier`) on its own line above `Feature:` (2-space indent).
+     Each scenario keeps just its unique id tag — that satisfies
+     `required-tags`, and no two scenarios share scenario-level tags so
+     `no-homogenous-tags` is silent.
+   - **Multi-scenario, mixed tiers** (like the pilot, where some
+     scenarios are basic and others are full) → keep the tier tag on
+     each individual scenario alongside its unique id.
+   - **Single-scenario file** → put the tag set at **both** Feature
+     level *and* Scenario level. `no-homogenous-tags` is satisfied
+     because the tags exist at Feature level; `required-tags` is
+     satisfied because the Scenario has its own tag line. Yes, this
+     duplicates the tags. Yes, both rules are simultaneously demanding
+     it. Don't try to remove either copy without re-running CI.
 3. Decide whether to use a `Background:` block:
    - 2+ scenarios → factor common setup into a `Background:`.
    - Exactly 1 scenario → inline the setup steps directly into that

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -18,10 +18,10 @@ and the reusable templates in
 |---|---|
 | Filename | `network-access-management-{operationId}.feature` (one file per `operationId`) |
 | Scenario tag | `@network_access_management_{operationId}_{NN}_{slug}` |
-| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placement depends on file shape: (a) **multi-scenario, single tier** → both `@basic_tier` and the unique scenario-id tag at Feature level only, scenarios carry no tags of their own; (b) **multi-scenario, mixed tiers** (like the pilot) → tier tag on each individual scenario alongside its unique id; (c) **single-scenario** → both tags at Feature level only (do not duplicate at the Scenario — that fires `no-superfluous-tags`). The interacting `gherkin-lint` rules to keep in mind: `no-homogenous-tags`, `required-tags`, `no-superfluous-tags`, `indentation`. Run `gherkin-lint` locally before pushing — see "Executing the tests" below. |
-| Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; skip when running against a facade in auth-disabled mode |
+| Tier tag | `@basic_tier` (release-candidate gate) or `@full_tier` (public-release gate). Placement: (a) **multi-scenario, single tier** → at Feature level (above `Feature:`, 2-space indent), with each scenario carrying just its unique id tag; (b) **multi-scenario, mixed tiers** (the pilot and every Group B file in this repo, which mix one `@basic_tier` happy path with one `@full_tier @requires_oidc` 401 scenario) → tier tag on each individual scenario alongside its unique id; no Feature-level tier tag. The four interacting `gherkin-lint` rules: `no-homogenous-tags` (scenarios may not all share a tag at scenario level), `required-tags` (every Scenario must have ≥1 tag), `no-superfluous-tags` (no tag duplicated across Feature and Scenario), `indentation` (2-space indent for tags). |
+| Auth-dependent tag | `@requires_oidc` — scenario requires real OIDC enforcement; auto-skip when running against a facade in auth-disabled mode |
 | Backend-dependent tag | `@backend_controlled` — scenario depends on backend state the facade alone cannot drive (e.g. 409 conflicts) |
-| Setup steps | For files with **2+ scenarios**, factored into a `Background:` block (`apiRoot` + resource + `Authorization` with required scope + `x-correlator` schema check, plus `Content-Type` and a default-valid request body for write ops). For files with a **single scenario**, inlined directly into the scenario — `Background:` is disallowed by `gherkin-lint`'s `no-background-only-scenario`. |
+| Setup steps | Always factored into a `Background:` block (`apiRoot` + resource + `Authorization` with required scope + `x-correlator` schema check, plus `Content-Type` and a default-valid request body for write ops, plus any path parameters shared across all scenarios). Every file in this directory has at least 2 scenarios — single-scenario files cannot satisfy the lint rule trio above, which is why Group B GETs each carry a 401 `@requires_oidc` scenario alongside the happy path. |
 | Schema references | JSON Pointer into the **bundled** OAS (e.g. `/components/schemas/TrustDomain`), not into `modules/...` |
 | Error-code coverage | One named `Scenario:` per documented response code; `Scenario Outline:` for parameter-varied cases (e.g. each missing-required-field permutation) |
 
@@ -37,10 +37,18 @@ Per the CAMARA API Testing Guidelines:
   (GET-after-POST agreement).
 
 `network-access-management-createTrustDomain.feature` is authored at the
-**full tier** as the canonical exemplar. The other 19 operations are
-authored at the **basic tier** only — happy-path scenarios sufficient for
-the release-candidate gate. Their full-tier rainy-day matrices are tracked
-as a follow-up workstream against the public-release readiness gate; see
+**full tier** as the canonical exemplar — happy paths plus the full
+400/401/403/409 error matrix.
+
+The other 19 operations are authored at **basic tier** for sunny-day
+coverage. The 9 single-resource GETs additionally include a `401`
+unauthenticated scenario (tagged `@full_tier @requires_oidc`) — added to
+satisfy the `gherkin-lint` rule trio that rejects single-scenario files,
+and serves as the seed for further full-tier expansion. Group A
+multi-scenario files (Trust Domain CRUD, Trust Domain Device CRUD,
+Reboot Request CRUD) remain basic-tier-only for now; their full-tier
+rainy-day matrices are tracked as a follow-up workstream against the
+public-release readiness gate; see
 [issue #52](https://github.com/camaraproject/NetworkAccessManagement/issues/52).
 
 ## File inventory
@@ -55,8 +63,9 @@ One `.feature` file per operationId, 20 files total, all committed.
 | Network Access Devices | `getNetworkAccessDevices`, `getNetworkAccessDevice` |
 | Reboot Requests | `createRebootRequest`, `getRebootRequests`, `getRebootRequest`, `updateRebootRequest`, `deleteRebootRequest` |
 
-`*` = full-tier exemplar; the remaining 19 are basic-tier only pending the
-follow-up rainy-day matrices.
+`*` = full-tier exemplar (full 4xx error matrix). The remaining 19 are
+basic-tier with a 401 `@requires_oidc` scenario added in each Group B
+GET file (see Coverage tiers above).
 
 ## Executing the tests
 
@@ -81,49 +90,68 @@ Examples of compatible runner stacks: Behave + `requests` + `openapi-core`
 committed to this repository — it is environment-specific and lives in
 the consuming organization's test infrastructure.
 
+## Local lint (run CI's `gherkin-lint` before you push)
+
+CAMARA's centralized lint is what trips PRs to this repo. Reproduce its
+gherkin-lint check locally with the exact rule config the CI uses:
+
+```bash
+# from anywhere
+curl -sSL https://raw.githubusercontent.com/camaraproject/tooling/v0/linting/config/.gherkin-lintrc \
+  -o /tmp/camara.gherkin-lintrc
+npx --yes gherkin-lint -c /tmp/camara.gherkin-lintrc code/Test_definitions/
+```
+
+Exit 0 means the gherkin step in CI will pass. The rules most likely to
+catch new authoring mistakes (and the order they typically fire in):
+`indentation` (tags need 2-space indent), `no-homogenous-tags` (don't
+repeat the same tag on every Scenario), `required-tags` (every Scenario
+needs ≥1 tag matching `^@.*$`), `no-superfluous-tags` (don't put the
+same tag at Feature *and* Scenario level), `no-background-only-scenario`
+(no `Background:` in a file that only has one Scenario).
+
+For the broader MegaLinter pipeline (Spectral on the OAS, yamllint, etc.)
+use `npx mega-linter-runner` — that pulls the same Docker image CI runs.
+
 ## Authoring guidance
 
 When adding a new file:
 
-1. Start from the pilot (`network-access-management-createTrustDomain.feature`)
-   for the multi-scenario / mixed-tier shape, or from any of the GET-by-id
-   files (e.g. `network-access-management-getService.feature`) for the
-   single-scenario shape with inlined setup steps.
-2. Decide where the tier tag goes based on the file's contents. Four
-   interacting `gherkin-lint` rules apply: `no-homogenous-tags`,
-   `required-tags`, `no-superfluous-tags`, and `indentation` (2-space
-   indent for tags).
-   - **Multi-scenario, all the same tier** → put `@basic_tier` (or
+1. Start from any existing file as a template:
+   - Full-tier: [`network-access-management-createTrustDomain.feature`](network-access-management-createTrustDomain.feature)
+     for write operations with the full error matrix.
+   - Basic-tier multi-scenario CRUD: any of the Trust Domain or Reboot
+     Request CRUD files for the standard Background + multiple-scenario
+     shape with each scenario carrying just its unique id tag.
+   - GET endpoint with a 401 escape hatch: any of the Group B files (e.g.
+     [`network-access-management-getService.feature`](network-access-management-getService.feature))
+     for the happy-path + 401 `@requires_oidc` pattern.
+2. **Every file must have ≥2 Scenarios.** Single-scenario files cannot
+   satisfy the `gherkin-lint` rule trio (`no-homogenous-tags`,
+   `required-tags`, `no-superfluous-tags`) — every tag arrangement
+   triggers at least one rule. If the operation truly has only one
+   sunny-day case, add a 401 `@requires_oidc` scenario as the second
+   scenario; that's what every Group B GET file does.
+3. Decide where the tier tag goes:
+   - **All scenarios at the same tier** → put `@basic_tier` (or
      `@full_tier`) on its own line above `Feature:` (2-space indent).
-     Each scenario keeps just its unique id tag — that satisfies
-     `required-tags`, no two scenarios share scenario-level tags so
-     `no-homogenous-tags` is silent, and no tag is duplicated across
-     levels so `no-superfluous-tags` is silent.
-   - **Multi-scenario, mixed tiers** (like the pilot, where some
-     scenarios are basic and others are full) → keep the tier tag on
-     each individual scenario alongside its unique id.
-   - **Single-scenario file** → put both `@basic_tier` and the unique
-     scenario id at Feature level (combined on one line, 2-space
-     indent). Do **not** repeat them above the Scenario — that fires
-     `no-superfluous-tags`. Note: this configuration depends on the
-     centralized CAMARA gherkin-lint config not enforcing
-     `required-tags` strictly on Scenario lines that inherit Feature
-     tags. **Always validate locally** with `gherkin-lint` before
-     pushing to avoid the rule-interaction surprises this PR
-     repeatedly hit (see "Executing the tests" for the recipe).
-3. Decide whether to use a `Background:` block:
-   - 2+ scenarios → factor common setup into a `Background:`.
-   - Exactly 1 scenario → inline the setup steps directly into that
-     scenario; `gherkin-lint`'s `no-background-only-scenario` rejects a
-     `Background:` with only one consumer.
-4. For request-body operations, adapt scenarios from
+     Each scenario carries just its unique id tag.
+   - **Mixed tiers** (e.g. one basic-tier happy path plus a full-tier
+     `@requires_oidc` scenario, like every Group B file) → keep the tier
+     tag on each individual scenario alongside its unique id; no
+     Feature-level tier tag.
+4. Factor common setup into a `Background:` block: `apiRoot`, resource
+   path, `Content-Type` (write ops only), `Authorization` plus the
+   required scope, `x-correlator` schema check, the default-valid
+   request body (write ops), and any path parameters shared across
+   scenarios.
+5. For request-body operations, adapt scenarios from
    [`syntax-errors-template.feature`](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/syntax-errors-template.feature).
-5. For full-tier expansion, confirm every documented error status in the
+6. For full-tier expansion, confirm every documented error status in the
    OAS has at least one scenario.
-6. Run the Gherkin syntax check before committing:
-   `npx @cucumber/gherkin-utils format <file>`. The MegaLinter job in CI
-   additionally runs `gherkin-lint`; the rules called out above
-   (`no-homogenous-tags`, `no-background-only-scenario`) are the ones
-   that have caught past PRs.
-7. Tag scope-/auth-dependent scenarios with `@requires_oidc` so they are
+7. **Validate locally** with the recipe in "Local lint" above. Exit 0
+   means CI's gherkin step will pass. Do this every time before
+   committing — every CI lint failure on this PR was something
+   catchable in five seconds locally.
+8. Tag scope-/auth-dependent scenarios with `@requires_oidc` so they are
    automatically skipped in environments without an OIDC server.

--- a/code/Test_definitions/README.md
+++ b/code/Test_definitions/README.md
@@ -36,15 +36,16 @@ Per the CAMARA API Testing Guidelines:
   validation, optional-field combinations, and CRUD state coherence
   (GET-after-POST agreement).
 
-The current pilot file (`network-access-management-createTrustDomain.feature`)
-is authored at the full tier as the canonical exemplar. Subsequent files in
-this directory will be added at basic tier first, then expanded.
+`network-access-management-createTrustDomain.feature` is authored at the
+**full tier** as the canonical exemplar. The other 19 operations are
+authored at the **basic tier** only — happy-path scenarios sufficient for
+the release-candidate gate. Their full-tier rainy-day matrices are tracked
+as a follow-up workstream against the public-release readiness gate; see
+[issue #52](https://github.com/camaraproject/NetworkAccessManagement/issues/52).
 
 ## File inventory
 
-The full target inventory is one `.feature` per operationId (20 files
-total). At present, only the pilot is committed; the rest are tracked in
-[issue #52](https://github.com/camaraproject/NetworkAccessManagement/issues/52).
+One `.feature` file per operationId, 20 files total, all committed.
 
 | Tag group | Operations |
 |---|---|
@@ -54,7 +55,8 @@ total). At present, only the pilot is committed; the rest are tracked in
 | Network Access Devices | `getNetworkAccessDevices`, `getNetworkAccessDevice` |
 | Reboot Requests | `createRebootRequest`, `getRebootRequests`, `getRebootRequest`, `updateRebootRequest`, `deleteRebootRequest` |
 
-`*` = pilot, full-tier exemplar already committed.
+`*` = full-tier exemplar; the remaining 19 are basic-tier only pending the
+follow-up rainy-day matrices.
 
 ## Executing the tests
 

--- a/code/Test_definitions/network-access-management-createRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-createRebootRequest.feature
@@ -1,0 +1,43 @@
+Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequest
+  # Operation: POST /reboot-requests
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 201, 400, 401, 403, 404, 409, 422, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_createRebootRequest_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common createRebootRequest setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/reboot-requests"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the request body is set by default to a request body compliant with the schema at "/components/schemas/RebootRequestCreate"
+
+  @network_access_management_createRebootRequest_01_immediate_default_device_success @basic_tier
+  Scenario: Request an immediate reboot of the default device (implicit targeting)
+    Given the calling subscriber has exactly one reboot-capable Network Access Device
+    And the API provider supports default-device inference
+    And the request body is set to the example "RebootRequestCreateImmediateDefaultDevice" of the schema "RebootRequestCreate"
+    When the request "createRebootRequest" is sent
+    Then the response status code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/RebootRequest"
+    And the response property "$.id" is a valid UUID
+    And the response property "$.devices" is an array of length 1 containing the inferred default device id
+
+  @network_access_management_createRebootRequest_02_scheduled_explicit_devices_success @basic_tier
+  Scenario: Schedule a reboot for an explicit list of multiple devices
+    Given the calling subscriber has at least two reboot-capable Network Access Devices
+    And the request body is set to the example "RebootRequestCreateScheduledMultipleDevices" of the schema "RebootRequestCreate"
+    And the request body property "$.atTime" is set to a valid RFC 3339 date-time at least 1 hour in the future
+    When the request "createRebootRequest" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/RebootRequest"
+    And the response property "$.devices" matches the request body property "$.devices"
+    And the response property "$.atTime" is the same as the request body property "$.atTime"

--- a/code/Test_definitions/network-access-management-createRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-createRebootRequest.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequest
   # Operation: POST /reboot-requests
   # Required scope: network-access-management:reboot
@@ -18,7 +19,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequ
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/RebootRequestCreate"
 
-  @network_access_management_createRebootRequest_01_immediate_default_device_success @basic_tier
+  @network_access_management_createRebootRequest_01_immediate_default_device_success
   Scenario: Request an immediate reboot of the default device (implicit targeting)
     Given the calling subscriber has exactly one reboot-capable Network Access Device
     And the API provider supports default-device inference
@@ -31,7 +32,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequ
     And the response property "$.id" is a valid UUID
     And the response property "$.devices" is an array of length 1 containing the inferred default device id
 
-  @network_access_management_createRebootRequest_02_scheduled_explicit_devices_success @basic_tier
+  @network_access_management_createRebootRequest_02_scheduled_explicit_devices_success
   Scenario: Schedule a reboot for an explicit list of multiple devices
     Given the calling subscriber has at least two reboot-capable Network Access Devices
     And the request body is set to the example "RebootRequestCreateScheduledMultipleDevices" of the schema "RebootRequestCreate"

--- a/code/Test_definitions/network-access-management-createRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-createRebootRequest.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequest
   # Operation: POST /reboot-requests
   # Required scope: network-access-management:reboot

--- a/code/Test_definitions/network-access-management-createRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-createRebootRequest.feature
@@ -9,6 +9,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequ
   # - @basic_tier  release-candidate gate (sunny-day + schema validation)
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
+  # Pending full-tier coverage: 400, 401, 403, 404, 409, 422.
 
   Background: Common createRebootRequest setup
     Given an environment at "apiRoot"
@@ -19,7 +20,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation createRebootRequ
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/RebootRequestCreate"
 
-  @network_access_management_createRebootRequest_01_immediate_default_device_success
+  @network_access_management_createRebootRequest_01_immediate_default_device_success @backend_controlled
   Scenario: Request an immediate reboot of the default device (implicit targeting)
     Given the calling subscriber has exactly one reboot-capable Network Access Device
     And the API provider supports default-device inference

--- a/code/Test_definitions/network-access-management-createTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-createTrustDomain.feature
@@ -125,7 +125,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomai
   @network_access_management_createTrustDomain_400_05_access_type_payload_mismatch @full_tier
   Scenario: accessType discriminator does not match the supplied accessDetail variant
     Given the request body property "$.accessDetails[0].accessType" is set to "Thread:STRUCTURED"
-    And the request body property "$.accessDetails[0]" otherwise contains Wi-Fi:WPA_PERSONAL fields
+    And the request body property "$.accessDetails[0]" contains the fields of a Wi-Fi:WPA_PERSONAL accessDetail except for "accessType"
     When the request "createTrustDomain" is sent
     Then the response status code is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
@@ -190,6 +190,9 @@ Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomai
 
   @network_access_management_createTrustDomain_403_02_read_only_scope @full_tier @requires_oidc
   Scenario: Access token has only the :read-all variant, which does not authorize creation
+    # Background's Authorization step set a valid :trust-domains-scoped token; the
+    # Given below replaces it with a :read-all-only token to verify that scope alone
+    # cannot authorize creation.
     Given the access token is replaced with one whose only NAM scope is "network-access-management:trust-domains:read-all"
     When the request "createTrustDomain" is sent
     Then the response status code is 403

--- a/code/Test_definitions/network-access-management-createTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-createTrustDomain.feature
@@ -1,0 +1,208 @@
+Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomain
+  # Reference:
+  # - API spec: https://github.com/camaraproject/NetworkAccessManagement/blob/main/code/API_definitions/network-access-management.yaml
+  # - CAMARA API Testing Guidelines: https://github.com/camaraproject/Commonalities/blob/main/documentation/API-Testing-Guidelines.md
+  #
+  # Operation: POST /trust-domains
+  # Required scope: network-access-management:trust-domains
+  # Documented response codes: 201, 400, 401, 403, 409, 500, 503
+  #
+  # Tagging conventions used in this file:
+  # - @network_access_management_createTrustDomain_NN_<slug>  unique scenario id
+  # - @basic_tier        scenario is part of the release-candidate basic test plan
+  # - @full_tier         scenario only required for the full (public-release) test plan
+  # - @requires_oidc     scenario depends on real OIDC enforcement at the API provider
+  #                      (skip when running against a facade in auth-disabled mode)
+
+  Background: Common createTrustDomain setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:trust-domains"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the request body is set by default to a request body compliant with the schema at "/components/schemas/TrustDomainCreate"
+  # =====================================================================
+  # Sunny-day scenarios (basic tier; sufficient for release-candidate)
+  # =====================================================================
+
+  @network_access_management_createTrustDomain_01_wpa2_personal_success @basic_tier
+  Scenario: Create a Trust Domain with WPA2-Personal Wi-Fi access
+    Given the request body is set to the example "TrustDomainCreateWpa2Personal" of the schema "TrustDomainCreate"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.id" is a valid UUID
+    And the response property "$.name" is the same as the request body property "$.name"
+    And the response property "$.enabled" is the same as the request body property "$.enabled"
+    And the response property "$.serviceId" is the same as the request body property "$.serviceId"
+    And the response property "$.accessDetails[0].accessType" is "Wi-Fi:WPA_PERSONAL"
+    And the response property "$.createdAt" is a valid RFC 3339 date-time with timezone
+
+  @network_access_management_createTrustDomain_02_inferred_ssid_success @basic_tier
+  Scenario: Create a Trust Domain with inferred (omitted) SSID
+    Given the request body is set to the example "TrustDomainCreateInferredSsid" of the schema "TrustDomainCreate"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.accessDetails[0].accessType" is "Wi-Fi:WPA_PERSONAL"
+    And the response property "$.accessDetails[0]" does not contain a property "ssid" or contains the SSID resolved by the network operator
+
+  @network_access_management_createTrustDomain_03_thread_structured_success @basic_tier
+  Scenario: Create a Trust Domain with Thread:STRUCTURED access
+    Given the request body is set to the example "TrustDomainCreateThreadStructured" of the schema "TrustDomainCreate"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.accessDetails[0].accessType" is "Thread:STRUCTURED"
+
+  @network_access_management_createTrustDomain_04_policies_success @basic_tier
+  Scenario: Create a Trust Domain with QoS / bandwidth policies
+    Given the request body is set to the example "TrustDomainCreateQoSPolicies" of the schema "TrustDomainCreate"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.policies" matches the request body property "$.policies"
+
+  @network_access_management_createTrustDomain_05_ephemeral_success @basic_tier
+  Scenario: Create an ephemeral Trust Domain with expiration
+    Given the request body is set to the example "TrustDomainCreateEphemeral" of the schema "TrustDomainCreate"
+    And the request body property "$.expiration" is set to a valid RFC 3339 date-time at least 1 hour in the future
+    When the request "createTrustDomain" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.expiration" is the same as the request body property "$.expiration"
+  # =====================================================================
+  # 400 INVALID_ARGUMENT — request shape / schema violations (full tier)
+  # Adapts patterns from Commonalities/artifacts/testing/syntax-errors-template.feature
+  # =====================================================================
+
+  @network_access_management_createTrustDomain_400_01_no_request_body @full_tier
+  Scenario: Missing request body
+    Given the request body is removed
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/ErrorInfo"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @network_access_management_createTrustDomain_400_02_empty_request_body @full_tier
+  Scenario: Empty object as request body
+    Given the request body is set to "{}"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @network_access_management_createTrustDomain_400_03_missing_required_property @full_tier
+  Scenario Outline: Missing a required top-level property in TrustDomainCreate
+    Given the request body property "<property>" is removed
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a reference to "<property>"
+
+    Examples:
+      | property        |
+      | $.name          |
+      | $.enabled       |
+      | $.accessDetails |
+      | $.serviceId     |
+
+  @network_access_management_createTrustDomain_400_04_invalid_access_type @full_tier
+  Scenario: Invalid accessType discriminator value
+    Given the request body property "$.accessDetails[0].accessType" is set to "Wi-Fi:UNKNOWN_PROFILE"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @network_access_management_createTrustDomain_400_05_access_type_payload_mismatch @full_tier
+  Scenario: accessType discriminator does not match the supplied accessDetail variant
+    Given the request body property "$.accessDetails[0].accessType" is set to "Thread:STRUCTURED"
+    And the request body property "$.accessDetails[0]" otherwise contains Wi-Fi:WPA_PERSONAL fields
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @network_access_management_createTrustDomain_400_06_invalid_service_id_format @full_tier
+  Scenario: serviceId is not a valid lowercase RFC 4122 v1-5 UUID
+    Given the request body property "$.serviceId" is set to "NOT-A-UUID"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @network_access_management_createTrustDomain_400_07_empty_access_details @full_tier
+  Scenario: accessDetails array is empty (violates minItems: 1)
+    Given the request body property "$.accessDetails" is set to "[]"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+
+  @network_access_management_createTrustDomain_400_08_invalid_expiration @full_tier
+  Scenario: expiration is not RFC 3339 with timezone
+    Given the request body is set to the example "TrustDomainCreateEphemeral" of the schema "TrustDomainCreate"
+    And the request body property "$.expiration" is set to "2024-12-31 23:59:59"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+  # =====================================================================
+  # 401 UNAUTHENTICATED — auth presence / validity (full tier; requires real OIDC enforcement)
+  # =====================================================================
+
+  @network_access_management_createTrustDomain_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "createTrustDomain" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+
+  @network_access_management_createTrustDomain_401_02_expired_token @full_tier @requires_oidc
+  Scenario: Expired access token
+    Given the header "Authorization" is set to an expired access token
+    When the request "createTrustDomain" is sent
+    Then the response status code is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+
+  @network_access_management_createTrustDomain_401_03_malformed_token @full_tier @requires_oidc
+  Scenario: Malformed access token
+    Given the header "Authorization" is set to "Bearer not-a-jwt"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+  # =====================================================================
+  # 403 PERMISSION_DENIED — scope / authorization (full tier; requires real OIDC enforcement)
+  # =====================================================================
+
+  @network_access_management_createTrustDomain_403_01_missing_scope @full_tier @requires_oidc
+  Scenario: Access token does not include the network-access-management:trust-domains scope
+    Given the access token is replaced with one that does not contain the scope "network-access-management:trust-domains"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+
+  @network_access_management_createTrustDomain_403_02_read_only_scope @full_tier @requires_oidc
+  Scenario: Access token has only the :read-all variant, which does not authorize creation
+    Given the access token is replaced with one whose only NAM scope is "network-access-management:trust-domains:read-all"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
+  # =====================================================================
+  # 409 CONFLICT — business-rule conflict (full tier)
+  # =====================================================================
+
+  @network_access_management_createTrustDomain_409_01_duplicate_name @full_tier @backend_controlled
+  Scenario: A Trust Domain with the same name already exists for this caller and serviceId
+    Given a Trust Domain with name "Duplicate Test TD" already exists for the caller against the same serviceId
+    And the request body property "$.name" is set to "Duplicate Test TD"
+    When the request "createTrustDomain" is sent
+    Then the response status code is 409
+    And the response property "$.status" is 409
+    And the response property "$.code" is "CONFLICT"

--- a/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
@@ -1,0 +1,46 @@
+Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomainDevice
+  # Operation: POST /trust-domains/{trustDomainId}/devices
+  # Required scope: network-access-management:devices
+  # Documented response codes: 201, 400, 401, 403, 404, 409, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_createTrustDomainDevice_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common createTrustDomainDevice setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:devices"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the request body is set by default to a request body compliant with the schema at "/components/schemas/TrustDomainDeviceCreate"
+    And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+
+  @network_access_management_createTrustDomainDevice_01_iot_success @basic_tier
+  Scenario: Register an IoT device with a hardware-address identifier
+    Given the request body is set to the example "TrustDomainDeviceCreateIoT" of the schema "TrustDomainDeviceCreate"
+    When the request "createTrustDomainDevice" is sent
+    Then the response status code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
+    And the response property "$.id" is a valid UUID
+    And the response property "$.deviceName" is the same as the request body property "$.deviceName"
+
+  @network_access_management_createTrustDomainDevice_02_minimal_success @basic_tier
+  Scenario: Register a device with the minimal valid payload
+    Given the request body is set to the example "TrustDomainDeviceCreateMinimal" of the schema "TrustDomainDeviceCreate"
+    When the request "createTrustDomainDevice" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
+
+  @network_access_management_createTrustDomainDevice_03_matter_success @basic_tier
+  Scenario: Register a Matter device with bootstrappingInfo
+    Given the request body is set to the example "TrustDomainDeviceCreateMatter" of the schema "TrustDomainDeviceCreate"
+    When the request "createTrustDomainDevice" is sent
+    Then the response status code is 201
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
+    And the response property "$.bootstrappingInfo" matches the request body property "$.bootstrappingInfo"

--- a/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomainDevice
   # Operation: POST /trust-domains/{trustDomainId}/devices
   # Required scope: network-access-management:devices

--- a/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomainDevice
   # Operation: POST /trust-domains/{trustDomainId}/devices
   # Required scope: network-access-management:devices
@@ -19,7 +20,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomai
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/TrustDomainDeviceCreate"
     And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
 
-  @network_access_management_createTrustDomainDevice_01_iot_success @basic_tier
+  @network_access_management_createTrustDomainDevice_01_iot_success
   Scenario: Register an IoT device with a hardware-address identifier
     Given the request body is set to the example "TrustDomainDeviceCreateIoT" of the schema "TrustDomainDeviceCreate"
     When the request "createTrustDomainDevice" is sent
@@ -30,14 +31,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomai
     And the response property "$.id" is a valid UUID
     And the response property "$.deviceName" is the same as the request body property "$.deviceName"
 
-  @network_access_management_createTrustDomainDevice_02_minimal_success @basic_tier
+  @network_access_management_createTrustDomainDevice_02_minimal_success
   Scenario: Register a device with the minimal valid payload
     Given the request body is set to the example "TrustDomainDeviceCreateMinimal" of the schema "TrustDomainDeviceCreate"
     When the request "createTrustDomainDevice" is sent
     Then the response status code is 201
     And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
 
-  @network_access_management_createTrustDomainDevice_03_matter_success @basic_tier
+  @network_access_management_createTrustDomainDevice_03_matter_success
   Scenario: Register a Matter device with bootstrappingInfo
     Given the request body is set to the example "TrustDomainDeviceCreateMatter" of the schema "TrustDomainDeviceCreate"
     When the request "createTrustDomainDevice" is sent

--- a/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-createTrustDomainDevice.feature
@@ -44,4 +44,4 @@ Feature: CAMARA Network Access Management API, vwip - Operation createTrustDomai
     When the request "createTrustDomainDevice" is sent
     Then the response status code is 201
     And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
-    And the response property "$.bootstrappingInfo" matches the request body property "$.bootstrappingInfo"
+    And the response property "$.bootstrappingInfo" is present and non-null

--- a/code/Test_definitions/network-access-management-deleteRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-deleteRebootRequest.feature
@@ -1,0 +1,33 @@
+Feature: CAMARA Network Access Management API, vwip - Operation deleteRebootRequest
+  # Operation: DELETE /reboot-requests/{rebootRequestId}
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 204, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_deleteRebootRequest_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common deleteRebootRequest setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_deleteRebootRequest_01_delete_success @basic_tier
+  Scenario: Delete (cancel) a pending Reboot Request
+    Given the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
+    When the request "deleteRebootRequest" is sent
+    Then the response status code is 204
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body is empty
+
+  @network_access_management_deleteRebootRequest_02_state_coherence_after_delete @basic_tier
+  Scenario: After successful deletion, GET on the same id returns 404
+    Given the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
+    And the request "deleteRebootRequest" has been sent and returned 204
+    When the request "getRebootRequest" is sent with the same rebootRequestId
+    Then the response status code is 404
+    And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/network-access-management-deleteRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-deleteRebootRequest.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation deleteRebootRequest
   # Operation: DELETE /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot

--- a/code/Test_definitions/network-access-management-deleteRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-deleteRebootRequest.feature
@@ -29,6 +29,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteRebootRequ
   Scenario: After successful deletion, GET on the same id returns 404
     Given the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
     And the request "deleteRebootRequest" has been sent and returned 204
-    When the request "getRebootRequest" is sent with the same rebootRequestId
+    When the request "getRebootRequest" is sent
     Then the response status code is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/network-access-management-deleteRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-deleteRebootRequest.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation deleteRebootRequest
   # Operation: DELETE /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot
@@ -16,7 +17,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteRebootRequ
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
-  @network_access_management_deleteRebootRequest_01_delete_success @basic_tier
+  @network_access_management_deleteRebootRequest_01_delete_success
   Scenario: Delete (cancel) a pending Reboot Request
     Given the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
     When the request "deleteRebootRequest" is sent
@@ -24,7 +25,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteRebootRequ
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body is empty
 
-  @network_access_management_deleteRebootRequest_02_state_coherence_after_delete @basic_tier
+  @network_access_management_deleteRebootRequest_02_state_coherence_after_delete
   Scenario: After successful deletion, GET on the same id returns 404
     Given the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
     And the request "deleteRebootRequest" has been sent and returned 204

--- a/code/Test_definitions/network-access-management-deleteTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomain.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomain
   # Operation: DELETE /trust-domains/{trustDomainId}
   # Required scope: network-access-management:trust-domains
@@ -16,7 +17,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomai
     And the access token has the scope "network-access-management:trust-domains"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
-  @network_access_management_deleteTrustDomain_01_delete_success @basic_tier
+  @network_access_management_deleteTrustDomain_01_delete_success
   Scenario: Delete a Trust Domain owned by the calling API client
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     When the request "deleteTrustDomain" is sent
@@ -24,7 +25,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomai
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body is empty
 
-  @network_access_management_deleteTrustDomain_02_state_coherence_after_delete @basic_tier
+  @network_access_management_deleteTrustDomain_02_state_coherence_after_delete
   Scenario: After successful deletion, GET on the same id returns 404 IDENTIFIER_NOT_FOUND
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the request "deleteTrustDomain" has been sent and returned 204

--- a/code/Test_definitions/network-access-management-deleteTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomain.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomain
   # Operation: DELETE /trust-domains/{trustDomainId}
   # Required scope: network-access-management:trust-domains

--- a/code/Test_definitions/network-access-management-deleteTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomain.feature
@@ -1,0 +1,33 @@
+Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomain
+  # Operation: DELETE /trust-domains/{trustDomainId}
+  # Required scope: network-access-management:trust-domains
+  # Documented response codes: 204, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_deleteTrustDomain_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common deleteTrustDomain setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:trust-domains"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_deleteTrustDomain_01_delete_success @basic_tier
+  Scenario: Delete a Trust Domain owned by the calling API client
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    When the request "deleteTrustDomain" is sent
+    Then the response status code is 204
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body is empty
+
+  @network_access_management_deleteTrustDomain_02_state_coherence_after_delete @basic_tier
+  Scenario: After successful deletion, GET on the same id returns 404 IDENTIFIER_NOT_FOUND
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the request "deleteTrustDomain" has been sent and returned 204
+    When the request "getTrustDomain" is sent with the same trustDomainId
+    Then the response status code is 404
+    And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/network-access-management-deleteTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomain.feature
@@ -29,6 +29,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomai
   Scenario: After successful deletion, GET on the same id returns 404 IDENTIFIER_NOT_FOUND
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the request "deleteTrustDomain" has been sent and returned 204
-    When the request "getTrustDomain" is sent with the same trustDomainId
+    When the request "getTrustDomain" is sent
     Then the response status code is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomainDevice
   # Operation: DELETE /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices

--- a/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomainDevice
   # Operation: DELETE /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices
@@ -16,7 +17,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomai
     And the access token has the scope "network-access-management:devices"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
-  @network_access_management_deleteTrustDomainDevice_01_delete_success @basic_tier
+  @network_access_management_deleteTrustDomainDevice_01_delete_success
   Scenario: Deregister a device from a Trust Domain
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
@@ -25,7 +26,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomai
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body is empty
 
-  @network_access_management_deleteTrustDomainDevice_02_state_coherence_after_delete @basic_tier
+  @network_access_management_deleteTrustDomainDevice_02_state_coherence_after_delete
   Scenario: After successful deregistration, GET on the same deviceId returns 404
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain

--- a/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
@@ -31,6 +31,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomai
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
     And the request "deleteTrustDomainDevice" has been sent and returned 204
-    When the request "getTrustDomainDevice" is sent with the same trustDomainId and deviceId
+    When the request "getTrustDomainDevice" is sent
     Then the response status code is 404
     And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-deleteTrustDomainDevice.feature
@@ -1,0 +1,35 @@
+Feature: CAMARA Network Access Management API, vwip - Operation deleteTrustDomainDevice
+  # Operation: DELETE /trust-domains/{trustDomainId}/devices/{deviceId}
+  # Required scope: network-access-management:devices
+  # Documented response codes: 204, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_deleteTrustDomainDevice_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common deleteTrustDomainDevice setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:devices"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_deleteTrustDomainDevice_01_delete_success @basic_tier
+  Scenario: Deregister a device from a Trust Domain
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
+    When the request "deleteTrustDomainDevice" is sent
+    Then the response status code is 204
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body is empty
+
+  @network_access_management_deleteTrustDomainDevice_02_state_coherence_after_delete @basic_tier
+  Scenario: After successful deregistration, GET on the same deviceId returns 404
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
+    And the request "deleteTrustDomainDevice" has been sent and returned 204
+    When the request "getTrustDomainDevice" is sent with the same trustDomainId and deviceId
+    Then the response status code is 404
+    And the response property "$.code" is "NOT_FOUND"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevice
   # Operation: GET /network-access-devices/{networkAccessDeviceId}
   # Required scope: network-access-management:reboot
@@ -9,16 +10,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getNetworkAccessDevice setup
+  @network_access_management_getNetworkAccessDevice_01_get_by_id_success
+  Scenario: Retrieve a Network Access Device by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices/{networkAccessDeviceId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getNetworkAccessDevice_01_get_by_id_success @basic_tier
-  Scenario: Retrieve a Network Access Device by its id
-    Given the path parameter "networkAccessDeviceId" is set to the id of a Network Access Device associated with the subscriber
+    And the path parameter "networkAccessDeviceId" is set to the id of a Network Access Device associated with the subscriber
     When the request "getNetworkAccessDevice" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getNetworkAccessDevice_01_get_by_id_success
   Scenario: Retrieve a Network Access Device by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices/{networkAccessDeviceId}"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getNetworkAccessDevice_01_get_by_id_success
   Scenario: Retrieve a Network Access Device by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices/{networkAccessDeviceId}"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
@@ -1,25 +1,35 @@
-  @basic_tier @network_access_management_getNetworkAccessDevice_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevice
   # Operation: GET /network-access-devices/{networkAccessDeviceId}
   # Required scope: network-access-management:reboot
   # Documented response codes: 200, 401, 403, 404, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getNetworkAccessDevice_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: Retrieve a Network Access Device by its id
+  Background: Common getNetworkAccessDevice setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices/{networkAccessDeviceId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "networkAccessDeviceId" is set to the id of a Network Access Device associated with the subscriber
+
+  @network_access_management_getNetworkAccessDevice_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a Network Access Device by its id
     When the request "getNetworkAccessDevice" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/NetworkAccessDevice"
     And the response property "$.id" equals the path parameter "networkAccessDeviceId"
+
+  @network_access_management_getNetworkAccessDevice_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getNetworkAccessDevice" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getNetworkAccessDevice_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevice
   # Operation: GET /network-access-devices/{networkAccessDeviceId}
   # Required scope: network-access-management:reboot
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getNetworkAccessDevice_01_get_by_id_success
   Scenario: Retrieve a Network Access Device by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices/{networkAccessDeviceId}"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevice.feature
@@ -1,0 +1,27 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevice
+  # Operation: GET /network-access-devices/{networkAccessDeviceId}
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getNetworkAccessDevice_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getNetworkAccessDevice setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/network-access-devices/{networkAccessDeviceId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getNetworkAccessDevice_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a Network Access Device by its id
+    Given the path parameter "networkAccessDeviceId" is set to the id of a Network Access Device associated with the subscriber
+    When the request "getNetworkAccessDevice" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/NetworkAccessDevice"
+    And the response property "$.id" equals the path parameter "networkAccessDeviceId"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
@@ -1,24 +1,34 @@
-  @basic_tier @network_access_management_getNetworkAccessDevices_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevices
   # Operation: GET /network-access-devices
   # Required scope: network-access-management:reboot
   # Documented response codes: 200, 401, 403, 404, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getNetworkAccessDevices_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: List Network Access Devices associated with the subscriber
+  Background: Common getNetworkAccessDevices setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getNetworkAccessDevices_01_list_success @basic_tier
+  Scenario: List Network Access Devices associated with the subscriber
     When the request "getNetworkAccessDevices" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/NetworkAccessDeviceList"
     And every NetworkAccessDevice entry in the response body complies with the schema at "/components/schemas/NetworkAccessDevice"
+
+  @network_access_management_getNetworkAccessDevices_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getNetworkAccessDevices" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getNetworkAccessDevices_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevices
   # Operation: GET /network-access-devices
   # Required scope: network-access-management:reboot
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getNetworkAccessDevices_01_list_success
   Scenario: List Network Access Devices associated with the subscriber
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getNetworkAccessDevices_01_list_success
   Scenario: List Network Access Devices associated with the subscriber
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getNetworkAccessDevices_01_list_success
   Scenario: List Network Access Devices associated with the subscriber
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
@@ -1,0 +1,26 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevices
+  # Operation: GET /network-access-devices
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getNetworkAccessDevices_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getNetworkAccessDevices setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/network-access-devices"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getNetworkAccessDevices_01_list_success @basic_tier
+  Scenario: List Network Access Devices associated with the subscriber
+    When the request "getNetworkAccessDevices" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/NetworkAccessDeviceList"
+    And every NetworkAccessDevice entry in the response body complies with the schema at "/components/schemas/NetworkAccessDevice"

--- a/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
+++ b/code/Test_definitions/network-access-management-getNetworkAccessDevices.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccessDevices
   # Operation: GET /network-access-devices
   # Required scope: network-access-management:reboot
@@ -9,15 +10,13 @@ Feature: CAMARA Network Access Management API, vwip - Operation getNetworkAccess
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getNetworkAccessDevices setup
+  @network_access_management_getNetworkAccessDevices_01_list_success
+  Scenario: List Network Access Devices associated with the subscriber
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/network-access-devices"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getNetworkAccessDevices_01_list_success @basic_tier
-  Scenario: List Network Access Devices associated with the subscriber
     When the request "getNetworkAccessDevices" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequest.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getRebootRequest_01_get_by_id_success
   Scenario: Retrieve a Reboot Request by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"

--- a/code/Test_definitions/network-access-management-getRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequest.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getRebootRequest_01_get_by_id_success
   Scenario: Retrieve a Reboot Request by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"

--- a/code/Test_definitions/network-access-management-getRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequest.feature
@@ -1,0 +1,27 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
+  # Operation: GET /reboot-requests/{rebootRequestId}
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getRebootRequest_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getRebootRequest setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getRebootRequest_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a Reboot Request by its id
+    Given the path parameter "rebootRequestId" is set to the id of a Reboot Request created by the calling API client
+    When the request "getRebootRequest" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/RebootRequest"
+    And the response property "$.id" equals the path parameter "rebootRequestId"

--- a/code/Test_definitions/network-access-management-getRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequest.feature
@@ -1,25 +1,35 @@
-  @basic_tier @network_access_management_getRebootRequest_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Operation: GET /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot
   # Documented response codes: 200, 401, 403, 404, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getRebootRequest_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: Retrieve a Reboot Request by its id
+  Background: Common getRebootRequest setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "rebootRequestId" is set to the id of a Reboot Request created by the calling API client
+
+  @network_access_management_getRebootRequest_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a Reboot Request by its id
     When the request "getRebootRequest" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/RebootRequest"
     And the response property "$.id" equals the path parameter "rebootRequestId"
+
+  @network_access_management_getRebootRequest_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getRebootRequest" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequest.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Operation: GET /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot
@@ -9,16 +10,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getRebootRequest setup
+  @network_access_management_getRebootRequest_01_get_by_id_success
+  Scenario: Retrieve a Reboot Request by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getRebootRequest_01_get_by_id_success @basic_tier
-  Scenario: Retrieve a Reboot Request by its id
-    Given the path parameter "rebootRequestId" is set to the id of a Reboot Request created by the calling API client
+    And the path parameter "rebootRequestId" is set to the id of a Reboot Request created by the calling API client
     When the request "getRebootRequest" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequest.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getRebootRequest_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Operation: GET /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getRebootRequest_01_get_by_id_success
   Scenario: Retrieve a Reboot Request by its id
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"

--- a/code/Test_definitions/network-access-management-getRebootRequests.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequests.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getRebootRequests_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequests
   # Operation: GET /reboot-requests
   # Required scope: network-access-management:reboot
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getRebootRequests_01_list_success
   Scenario: List Reboot Requests created by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests"

--- a/code/Test_definitions/network-access-management-getRebootRequests.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequests.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getRebootRequests_01_list_success
   Scenario: List Reboot Requests created by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests"

--- a/code/Test_definitions/network-access-management-getRebootRequests.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequests.feature
@@ -1,0 +1,27 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequests
+  # Operation: GET /reboot-requests
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 200, 401, 403, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getRebootRequests_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getRebootRequests setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/reboot-requests"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getRebootRequests_01_list_success @basic_tier
+  Scenario: List Reboot Requests created by the calling API client
+    Given at least one Reboot Request exists for the calling API client
+    When the request "getRebootRequests" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body is an array
+    And every element of the response body complies with the schema at "/components/schemas/RebootRequest"

--- a/code/Test_definitions/network-access-management-getRebootRequests.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequests.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getRebootRequests_01_list_success
   Scenario: List Reboot Requests created by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests"

--- a/code/Test_definitions/network-access-management-getRebootRequests.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequests.feature
@@ -1,25 +1,35 @@
-  @basic_tier @network_access_management_getRebootRequests_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequests
   # Operation: GET /reboot-requests
   # Required scope: network-access-management:reboot
   # Documented response codes: 200, 401, 403, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getRebootRequests_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: List Reboot Requests created by the calling API client
+  Background: Common getRebootRequests setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-    And at least one Reboot Request exists for the calling API client
+
+  @network_access_management_getRebootRequests_01_list_success @basic_tier
+  Scenario: List Reboot Requests created by the calling API client
+    Given at least one Reboot Request exists for the calling API client
     When the request "getRebootRequests" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body is an array
     And every element of the response body complies with the schema at "/components/schemas/RebootRequest"
+
+  @network_access_management_getRebootRequests_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getRebootRequests" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getRebootRequests.feature
+++ b/code/Test_definitions/network-access-management-getRebootRequests.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequests
   # Operation: GET /reboot-requests
   # Required scope: network-access-management:reboot
@@ -9,16 +10,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation getRebootRequest
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getRebootRequests setup
+  @network_access_management_getRebootRequests_01_list_success
+  Scenario: List Reboot Requests created by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/reboot-requests"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:reboot"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getRebootRequests_01_list_success @basic_tier
-  Scenario: List Reboot Requests created by the calling API client
-    Given at least one Reboot Request exists for the calling API client
+    And at least one Reboot Request exists for the calling API client
     When the request "getRebootRequests" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getService.feature
+++ b/code/Test_definitions/network-access-management-getService.feature
@@ -1,25 +1,35 @@
-  @basic_tier @network_access_management_getService_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Operation: GET /services/{serviceId}
   # Required scope: network-access-management:services:read
   # Documented response codes: 200, 401, 403, 404, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getService_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: Retrieve a Service by its serviceId
+  Background: Common getService setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services/{serviceId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:services:read"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "serviceId" is set to a valid lowercase RFC 4122 UUID identifying a Service accessible to the caller
+
+  @network_access_management_getService_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a Service by its serviceId
     When the request "getService" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/Service"
     And the response property "$.id" equals the path parameter "serviceId"
+
+  @network_access_management_getService_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getService" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getService.feature
+++ b/code/Test_definitions/network-access-management-getService.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Operation: GET /services/{serviceId}
   # Required scope: network-access-management:services:read
@@ -9,16 +10,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getService setup
+  @network_access_management_getService_01_get_by_id_success
+  Scenario: Retrieve a Service by its serviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services/{serviceId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:services:read"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getService_01_get_by_id_success @basic_tier
-  Scenario: Retrieve a Service by its serviceId
-    Given the path parameter "serviceId" is set to a valid lowercase RFC 4122 UUID identifying a Service accessible to the caller
+    And the path parameter "serviceId" is set to a valid lowercase RFC 4122 UUID identifying a Service accessible to the caller
     When the request "getService" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getService.feature
+++ b/code/Test_definitions/network-access-management-getService.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getService_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Operation: GET /services/{serviceId}
   # Required scope: network-access-management:services:read
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getService_01_get_by_id_success
   Scenario: Retrieve a Service by its serviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services/{serviceId}"

--- a/code/Test_definitions/network-access-management-getService.feature
+++ b/code/Test_definitions/network-access-management-getService.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getService_01_get_by_id_success
   Scenario: Retrieve a Service by its serviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services/{serviceId}"

--- a/code/Test_definitions/network-access-management-getService.feature
+++ b/code/Test_definitions/network-access-management-getService.feature
@@ -1,0 +1,27 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getService
+  # Operation: GET /services/{serviceId}
+  # Required scope: network-access-management:services:read
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getService_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getService setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/services/{serviceId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:services:read"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getService_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a Service by its serviceId
+    Given the path parameter "serviceId" is set to a valid lowercase RFC 4122 UUID identifying a Service accessible to the caller
+    When the request "getService" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/Service"
+    And the response property "$.id" equals the path parameter "serviceId"

--- a/code/Test_definitions/network-access-management-getService.feature
+++ b/code/Test_definitions/network-access-management-getService.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getService
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getService_01_get_by_id_success
   Scenario: Retrieve a Service by its serviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services/{serviceId}"

--- a/code/Test_definitions/network-access-management-getServices.feature
+++ b/code/Test_definitions/network-access-management-getServices.feature
@@ -1,0 +1,26 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getServices
+  # Operation: GET /services
+  # Required scope: network-access-management:services:read
+  # Documented response codes: 200, 401, 403, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getServices_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getServices setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/services"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:services:read"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getServices_01_list_success @basic_tier
+  Scenario: List all Services accessible to the authenticated identity
+    When the request "getServices" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/ServiceList"
+    And every Service entry in the response body complies with the schema at "/components/schemas/Service"

--- a/code/Test_definitions/network-access-management-getServices.feature
+++ b/code/Test_definitions/network-access-management-getServices.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getServices_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Operation: GET /services
   # Required scope: network-access-management:services:read
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getServices_01_list_success
   Scenario: List all Services accessible to the authenticated identity
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services"

--- a/code/Test_definitions/network-access-management-getServices.feature
+++ b/code/Test_definitions/network-access-management-getServices.feature
@@ -1,24 +1,34 @@
-  @basic_tier @network_access_management_getServices_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Operation: GET /services
   # Required scope: network-access-management:services:read
   # Documented response codes: 200, 401, 403, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getServices_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: List all Services accessible to the authenticated identity
+  Background: Common getServices setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:services:read"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getServices_01_list_success @basic_tier
+  Scenario: List all Services accessible to the authenticated identity
     When the request "getServices" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/ServiceList"
     And every Service entry in the response body complies with the schema at "/components/schemas/Service"
+
+  @network_access_management_getServices_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getServices" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getServices.feature
+++ b/code/Test_definitions/network-access-management-getServices.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getServices_01_list_success
   Scenario: List all Services accessible to the authenticated identity
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services"

--- a/code/Test_definitions/network-access-management-getServices.feature
+++ b/code/Test_definitions/network-access-management-getServices.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Operation: GET /services
   # Required scope: network-access-management:services:read
@@ -9,15 +10,13 @@ Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getServices setup
+  @network_access_management_getServices_01_list_success
+  Scenario: List all Services accessible to the authenticated identity
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:services:read"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getServices_01_list_success @basic_tier
-  Scenario: List all Services accessible to the authenticated identity
     When the request "getServices" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getServices.feature
+++ b/code/Test_definitions/network-access-management-getServices.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getServices
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getServices_01_list_success
   Scenario: List all Services accessible to the authenticated identity
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/services"

--- a/code/Test_definitions/network-access-management-getTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomain.feature
@@ -1,0 +1,37 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomain
+  # Operation: GET /trust-domains/{trustDomainId}
+  # Required scope: network-access-management:trust-domains
+  #     OR        : network-access-management:trust-domains:read-all
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getTrustDomain_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getTrustDomain setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}"
+    And the header "Authorization" is set to a valid access token
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getTrustDomain_01_caller_owned_success @basic_tier
+  Scenario: Retrieve a Trust Domain owned by the calling API client
+    Given the access token has the scope "network-access-management:trust-domains"
+    And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    When the request "getTrustDomain" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.id" equals the path parameter "trustDomainId"
+
+  @network_access_management_getTrustDomain_02_read_all_success @basic_tier
+  Scenario: Retrieve a Trust Domain via the read-all scope
+    Given the access token has the scope "network-access-management:trust-domains:read-all"
+    And the path parameter "trustDomainId" is set to the id of a Trust Domain associated with the subscriber but created by a different API client
+    When the request "getTrustDomain" is sent
+    Then the response status code is 200
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.id" equals the path parameter "trustDomainId"

--- a/code/Test_definitions/network-access-management-getTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomain.feature
@@ -28,7 +28,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomain
     And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
     And the response property "$.id" equals the path parameter "trustDomainId"
 
-  @network_access_management_getTrustDomain_02_read_all_success
+  @network_access_management_getTrustDomain_02_read_all_success @backend_controlled
   Scenario: Retrieve a Trust Domain via the read-all scope
     Given the access token has the scope "network-access-management:trust-domains:read-all"
     And the path parameter "trustDomainId" is set to the id of a Trust Domain associated with the subscriber but created by a different API client

--- a/code/Test_definitions/network-access-management-getTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomain.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomain
   # Operation: GET /trust-domains/{trustDomainId}
   # Required scope: network-access-management:trust-domains
@@ -16,7 +17,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomain
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
-  @network_access_management_getTrustDomain_01_caller_owned_success @basic_tier
+  @network_access_management_getTrustDomain_01_caller_owned_success
   Scenario: Retrieve a Trust Domain owned by the calling API client
     Given the access token has the scope "network-access-management:trust-domains"
     And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
@@ -27,7 +28,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomain
     And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
     And the response property "$.id" equals the path parameter "trustDomainId"
 
-  @network_access_management_getTrustDomain_02_read_all_success @basic_tier
+  @network_access_management_getTrustDomain_02_read_all_success
   Scenario: Retrieve a Trust Domain via the read-all scope
     Given the access token has the scope "network-access-management:trust-domains:read-all"
     And the path parameter "trustDomainId" is set to the id of a Trust Domain associated with the subscriber but created by a different API client

--- a/code/Test_definitions/network-access-management-getTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomain.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomain
   # Operation: GET /trust-domains/{trustDomainId}
   # Required scope: network-access-management:trust-domains

--- a/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCapabilities
   # Operation: GET /trust-domains/capabilities
   # Required scope: network-access-management:trust-domains
@@ -9,15 +10,13 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCa
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getTrustDomainCapabilities setup
+  @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success
+  Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/capabilities"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:trust-domains"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success @basic_tier
-  Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
     When the request "getTrustDomainCapabilities" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"

--- a/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
@@ -1,23 +1,33 @@
-  @basic_tier @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCapabilities
   # Operation: GET /trust-domains/capabilities
   # Required scope: network-access-management:trust-domains
   # Documented response codes: 200, 401, 403, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getTrustDomainCapabilities_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
+  Background: Common getTrustDomainCapabilities setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/capabilities"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:trust-domains"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success @basic_tier
+  Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
     When the request "getTrustDomainCapabilities" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/TrustDomainCapabilities"
+
+  @network_access_management_getTrustDomainCapabilities_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getTrustDomainCapabilities" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
@@ -1,0 +1,25 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCapabilities
+  # Operation: GET /trust-domains/capabilities
+  # Required scope: network-access-management:trust-domains
+  # Documented response codes: 200, 401, 403, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getTrustDomainCapabilities_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getTrustDomainCapabilities setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/capabilities"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:trust-domains"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success @basic_tier
+  Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
+    When the request "getTrustDomainCapabilities" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainCapabilities"

--- a/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCa
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success
   Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/capabilities"

--- a/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCapabilities
   # Operation: GET /trust-domains/capabilities
   # Required scope: network-access-management:trust-domains
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCa
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success
   Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/capabilities"

--- a/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainCapabilities.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainCa
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getTrustDomainCapabilities_01_get_capabilities_success
   Scenario: Retrieve the Trust Domain capabilities advertised by the API provider
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/capabilities"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getTrustDomainDevice_01_get_by_id_success
   Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
@@ -1,16 +1,15 @@
-  @basic_tier @network_access_management_getTrustDomainDevice_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevice
   # Operation: GET /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices
   # Documented response codes: 200, 401, 403, 404, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getTrustDomainDevice_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
+  Background: Common getTrustDomainDevice setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"
     And the header "Authorization" is set to a valid access token
@@ -18,9 +17,20 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
+
+  @network_access_management_getTrustDomainDevice_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
     When the request "getTrustDomainDevice" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
     And the response property "$.id" equals the path parameter "deviceId"
+
+  @network_access_management_getTrustDomainDevice_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getTrustDomainDevice" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevice
   # Operation: GET /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices
@@ -9,16 +10,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getTrustDomainDevice setup
+  @network_access_management_getTrustDomainDevice_01_get_by_id_success
+  Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:devices"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getTrustDomainDevice_01_get_by_id_success @basic_tier
-  Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
-    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
     When the request "getTrustDomainDevice" is sent
     Then the response status code is 200

--- a/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
@@ -1,0 +1,28 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevice
+  # Operation: GET /trust-domains/{trustDomainId}/devices/{deviceId}
+  # Required scope: network-access-management:devices
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getTrustDomainDevice_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getTrustDomainDevice setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:devices"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getTrustDomainDevice_01_get_by_id_success @basic_tier
+  Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
+    When the request "getTrustDomainDevice" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
+    And the response property "$.id" equals the path parameter "deviceId"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getTrustDomainDevice_01_get_by_id_success
   Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevice.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getTrustDomainDevice_01_get_by_id_success
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevice
   # Operation: GET /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getTrustDomainDevice_01_get_by_id_success
   Scenario: Retrieve a single device registered to a Trust Domain by its deviceId
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevices
   # Operation: GET /trust-domains/{trustDomainId}/devices
   # Required scope: network-access-management:devices
@@ -9,16 +10,14 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  Background: Common getTrustDomainDevices setup
+  @network_access_management_getTrustDomainDevices_01_list_success
+  Scenario: List devices registered to a Trust Domain owned by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:devices"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
-
-  @network_access_management_getTrustDomainDevices_01_list_success @basic_tier
-  Scenario: List devices registered to a Trust Domain owned by the calling API client
-    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the Trust Domain has at least one device registered
     When the request "getTrustDomainDevices" is sent
     Then the response status code is 200

--- a/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @basic_tier @network_access_management_getTrustDomainDevices_01_list_success
   Scenario: List devices registered to a Trust Domain owned by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier @network_access_management_getTrustDomainDevices_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevices
   # Operation: GET /trust-domains/{trustDomainId}/devices
   # Required scope: network-access-management:devices
@@ -10,7 +10,6 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
-  @network_access_management_getTrustDomainDevices_01_list_success
   Scenario: List devices registered to a Trust Domain owned by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
@@ -1,0 +1,28 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevices
+  # Operation: GET /trust-domains/{trustDomainId}/devices
+  # Required scope: network-access-management:devices
+  # Documented response codes: 200, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getTrustDomainDevices_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getTrustDomainDevices setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:devices"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getTrustDomainDevices_01_list_success @basic_tier
+  Scenario: List devices registered to a Trust Domain owned by the calling API client
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the Trust Domain has at least one device registered
+    When the request "getTrustDomainDevices" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDeviceList"
+    And every TrustDomainDevice entry in the response body complies with the schema at "/components/schemas/TrustDomainDevice"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
@@ -1,26 +1,36 @@
-  @basic_tier @network_access_management_getTrustDomainDevices_01_list_success
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDevices
   # Operation: GET /trust-domains/{trustDomainId}/devices
   # Required scope: network-access-management:devices
   # Documented response codes: 200, 401, 403, 404, 500, 503
   #
-  # Tagging:
+  # Tagging conventions:
   # - @network_access_management_getTrustDomainDevices_NN_<slug>  unique scenario id
-  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
-  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
-  # against the public-release readiness gate; see issue #52.
+  # - @basic_tier   release-candidate gate (sunny-day + schema validation)
+  # - @full_tier    public-release gate (rainy-day matrix)
+  # - @requires_oidc scenario depends on real OIDC enforcement at the API provider
 
-  Scenario: List devices registered to a Trust Domain owned by the calling API client
+  Background: Common getTrustDomainDevices setup
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"
     And the header "Authorization" is set to a valid access token
     And the access token has the scope "network-access-management:devices"
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
-    And the Trust Domain has at least one device registered
+
+  @network_access_management_getTrustDomainDevices_01_list_success @basic_tier
+  Scenario: List devices registered to a Trust Domain owned by the calling API client
+    Given the Trust Domain has at least one device registered
     When the request "getTrustDomainDevices" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/TrustDomainDeviceList"
     And every TrustDomainDevice entry in the response body complies with the schema at "/components/schemas/TrustDomainDevice"
+
+  @network_access_management_getTrustDomainDevices_401_01_no_authorization_header @full_tier @requires_oidc
+  Scenario: No Authorization header
+    Given the header "Authorization" is removed
+    When the request "getTrustDomainDevices" is sent
+    Then the response status code is 401
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"

--- a/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomainDevices.feature
@@ -10,6 +10,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomainDe
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
 
+  @basic_tier @network_access_management_getTrustDomainDevices_01_list_success
   Scenario: List devices registered to a Trust Domain owned by the calling API client
     Given an environment at "apiRoot"
     And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices"

--- a/code/Test_definitions/network-access-management-getTrustDomains.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomains.feature
@@ -29,7 +29,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomains
     And every element of the response body complies with the schema at "/components/schemas/TrustDomain"
     And every element of the response body has a "createdBy" property identifying the calling API client
 
-  @network_access_management_getTrustDomains_02_read_all_success
+  @network_access_management_getTrustDomains_02_read_all_success @backend_controlled
   Scenario: List all Trust Domains visible to the subscriber via the read-all scope
     Given the access token has the scope "network-access-management:trust-domains:read-all"
     And at least one Trust Domain exists for the subscriber, created by another API client

--- a/code/Test_definitions/network-access-management-getTrustDomains.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomains.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomains
   # Operation: GET /trust-domains
   # Required scope: network-access-management:trust-domains
@@ -16,7 +17,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomains
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
-  @network_access_management_getTrustDomains_01_caller_owned_success @basic_tier
+  @network_access_management_getTrustDomains_01_caller_owned_success
   Scenario: List Trust Domains owned by the calling API client
     Given the access token has the scope "network-access-management:trust-domains"
     And at least one Trust Domain exists for the calling API client
@@ -28,7 +29,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomains
     And every element of the response body complies with the schema at "/components/schemas/TrustDomain"
     And every element of the response body has a "createdBy" property identifying the calling API client
 
-  @network_access_management_getTrustDomains_02_read_all_success @basic_tier
+  @network_access_management_getTrustDomains_02_read_all_success
   Scenario: List all Trust Domains visible to the subscriber via the read-all scope
     Given the access token has the scope "network-access-management:trust-domains:read-all"
     And at least one Trust Domain exists for the subscriber, created by another API client

--- a/code/Test_definitions/network-access-management-getTrustDomains.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomains.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomains
   # Operation: GET /trust-domains
   # Required scope: network-access-management:trust-domains

--- a/code/Test_definitions/network-access-management-getTrustDomains.feature
+++ b/code/Test_definitions/network-access-management-getTrustDomains.feature
@@ -1,0 +1,38 @@
+Feature: CAMARA Network Access Management API, vwip - Operation getTrustDomains
+  # Operation: GET /trust-domains
+  # Required scope: network-access-management:trust-domains
+  #     OR        : network-access-management:trust-domains:read-all
+  # Documented response codes: 200, 401, 403, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_getTrustDomains_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common getTrustDomains setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains"
+    And the header "Authorization" is set to a valid access token
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+  @network_access_management_getTrustDomains_01_caller_owned_success @basic_tier
+  Scenario: List Trust Domains owned by the calling API client
+    Given the access token has the scope "network-access-management:trust-domains"
+    And at least one Trust Domain exists for the calling API client
+    When the request "getTrustDomains" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body is an array
+    And every element of the response body complies with the schema at "/components/schemas/TrustDomain"
+    And every element of the response body has a "createdBy" property identifying the calling API client
+
+  @network_access_management_getTrustDomains_02_read_all_success @basic_tier
+  Scenario: List all Trust Domains visible to the subscriber via the read-all scope
+    Given the access token has the scope "network-access-management:trust-domains:read-all"
+    And at least one Trust Domain exists for the subscriber, created by another API client
+    When the request "getTrustDomains" is sent
+    Then the response status code is 200
+    And the response body is an array
+    And every element of the response body complies with the schema at "/components/schemas/TrustDomain"

--- a/code/Test_definitions/network-access-management-updateRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-updateRebootRequest.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation updateRebootRequest
   # Operation: PATCH /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot
@@ -19,7 +20,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateRebootRequ
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/RebootRequestUpdate"
     And the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
 
-  @network_access_management_updateRebootRequest_01_reschedule_success @basic_tier
+  @network_access_management_updateRebootRequest_01_reschedule_success
   Scenario: Reschedule a pending Reboot Request to a later atTime
     Given the request body property "$.atTime" is set to a valid RFC 3339 date-time at least 2 hours in the future
     When the request "updateRebootRequest" is sent
@@ -30,7 +31,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateRebootRequ
     And the response property "$.id" equals the path parameter "rebootRequestId"
     And the response property "$.atTime" is the same as the request body property "$.atTime"
 
-  @network_access_management_updateRebootRequest_02_cancel_success @basic_tier
+  @network_access_management_updateRebootRequest_02_cancel_success
   Scenario: Cancel a pending Reboot Request via PATCH
     Given the request body property "$.status" is set to a valid cancellation value per the RebootRequestUpdate schema
     When the request "updateRebootRequest" is sent

--- a/code/Test_definitions/network-access-management-updateRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-updateRebootRequest.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation updateRebootRequest
   # Operation: PATCH /reboot-requests/{rebootRequestId}
   # Required scope: network-access-management:reboot

--- a/code/Test_definitions/network-access-management-updateRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-updateRebootRequest.feature
@@ -9,6 +9,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateRebootRequ
   # - @basic_tier  release-candidate gate (sunny-day + schema validation)
   # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
   # against the public-release readiness gate; see issue #52.
+  # Pending full-tier coverage: 400, 401, 403, 404, 409, 422.
 
   Background: Common updateRebootRequest setup
     Given an environment at "apiRoot"

--- a/code/Test_definitions/network-access-management-updateRebootRequest.feature
+++ b/code/Test_definitions/network-access-management-updateRebootRequest.feature
@@ -1,0 +1,39 @@
+Feature: CAMARA Network Access Management API, vwip - Operation updateRebootRequest
+  # Operation: PATCH /reboot-requests/{rebootRequestId}
+  # Required scope: network-access-management:reboot
+  # Documented response codes: 200, 400, 401, 403, 404, 409, 422, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_updateRebootRequest_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common updateRebootRequest setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/reboot-requests/{rebootRequestId}"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:reboot"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the request body is set by default to a request body compliant with the schema at "/components/schemas/RebootRequestUpdate"
+    And the path parameter "rebootRequestId" is set to the id of a pending Reboot Request created by the calling API client
+
+  @network_access_management_updateRebootRequest_01_reschedule_success @basic_tier
+  Scenario: Reschedule a pending Reboot Request to a later atTime
+    Given the request body property "$.atTime" is set to a valid RFC 3339 date-time at least 2 hours in the future
+    When the request "updateRebootRequest" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/RebootRequest"
+    And the response property "$.id" equals the path parameter "rebootRequestId"
+    And the response property "$.atTime" is the same as the request body property "$.atTime"
+
+  @network_access_management_updateRebootRequest_02_cancel_success @basic_tier
+  Scenario: Cancel a pending Reboot Request via PATCH
+    Given the request body property "$.status" is set to a valid cancellation value per the RebootRequestUpdate schema
+    When the request "updateRebootRequest" is sent
+    Then the response status code is 200
+    And the response body complies with the OAS schema at "/components/schemas/RebootRequest"
+    And the response property "$.status" reflects the cancellation

--- a/code/Test_definitions/network-access-management-updateTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomain.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomain
   # Operation: PATCH /trust-domains/{trustDomainId}
   # Required scope: network-access-management:trust-domains
@@ -18,7 +19,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomai
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is set by default to a request body compliant with the schema at "/components/schemas/TrustDomainUpdate"
 
-  @network_access_management_updateTrustDomain_01_rename_success @basic_tier
+  @network_access_management_updateTrustDomain_01_rename_success
   Scenario: Rename an existing Trust Domain
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the request body property "$.name" is set to "Renamed Network"
@@ -31,7 +32,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomai
     And the response property "$.name" is "Renamed Network"
     And the response property "$.modifiedAt" is a valid RFC 3339 date-time with timezone
 
-  @network_access_management_updateTrustDomain_02_replace_access_details_success @basic_tier
+  @network_access_management_updateTrustDomain_02_replace_access_details_success
   Scenario: Replace the accessDetails array on an existing Trust Domain
     Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the request body property "$.accessDetails" is set to an array containing exactly one valid Wi-Fi:WPA_PERSONAL accessDetail
@@ -41,7 +42,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomai
     And the response property "$.accessDetails" has length 1
     And the response property "$.accessDetails[0].accessType" is "Wi-Fi:WPA_PERSONAL"
 
-  @network_access_management_updateTrustDomain_03_toggle_enabled_success @basic_tier
+  @network_access_management_updateTrustDomain_03_toggle_enabled_success
   Scenario: Disable an existing Trust Domain by toggling enabled to false
     Given the path parameter "trustDomainId" is set to the id of an enabled Trust Domain created by the calling API client
     And the request body property "$.enabled" is set to false

--- a/code/Test_definitions/network-access-management-updateTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomain.feature
@@ -1,0 +1,51 @@
+Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomain
+  # Operation: PATCH /trust-domains/{trustDomainId}
+  # Required scope: network-access-management:trust-domains
+  # Documented response codes: 200, 400, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_updateTrustDomain_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common updateTrustDomain setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:trust-domains"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the request body is set by default to a request body compliant with the schema at "/components/schemas/TrustDomainUpdate"
+
+  @network_access_management_updateTrustDomain_01_rename_success @basic_tier
+  Scenario: Rename an existing Trust Domain
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the request body property "$.name" is set to "Renamed Network"
+    When the request "updateTrustDomain" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.id" equals the path parameter "trustDomainId"
+    And the response property "$.name" is "Renamed Network"
+    And the response property "$.modifiedAt" is a valid RFC 3339 date-time with timezone
+
+  @network_access_management_updateTrustDomain_02_replace_access_details_success @basic_tier
+  Scenario: Replace the accessDetails array on an existing Trust Domain
+    Given the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the request body property "$.accessDetails" is set to an array containing exactly one valid Wi-Fi:WPA_PERSONAL accessDetail
+    When the request "updateTrustDomain" is sent
+    Then the response status code is 200
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.accessDetails" has length 1
+    And the response property "$.accessDetails[0].accessType" is "Wi-Fi:WPA_PERSONAL"
+
+  @network_access_management_updateTrustDomain_03_toggle_enabled_success @basic_tier
+  Scenario: Disable an existing Trust Domain by toggling enabled to false
+    Given the path parameter "trustDomainId" is set to the id of an enabled Trust Domain created by the calling API client
+    And the request body property "$.enabled" is set to false
+    When the request "updateTrustDomain" is sent
+    Then the response status code is 200
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomain"
+    And the response property "$.enabled" is false

--- a/code/Test_definitions/network-access-management-updateTrustDomain.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomain.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomain
   # Operation: PATCH /trust-domains/{trustDomainId}
   # Required scope: network-access-management:trust-domains

--- a/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
@@ -1,0 +1,41 @@
+Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomainDevice
+  # Operation: PATCH /trust-domains/{trustDomainId}/devices/{deviceId}
+  # Required scope: network-access-management:devices
+  # Documented response codes: 200, 400, 401, 403, 404, 500, 503
+  #
+  # Tagging:
+  # - @network_access_management_updateTrustDomainDevice_NN_<slug>  unique scenario id
+  # - @basic_tier  release-candidate gate (sunny-day + schema validation)
+  # Full-tier (rainy-day) scenarios are tracked as a follow-up workstream
+  # against the public-release readiness gate; see issue #52.
+
+  Background: Common updateTrustDomainDevice setup
+    Given an environment at "apiRoot"
+    And the resource "/network-access-management/vwip/trust-domains/{trustDomainId}/devices/{deviceId}"
+    And the header "Content-Type" is set to "application/json"
+    And the header "Authorization" is set to a valid access token
+    And the access token has the scope "network-access-management:devices"
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+    And the request body is set by default to a request body compliant with the schema at "/components/schemas/TrustDomainDeviceUpdate"
+    And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
+    And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
+
+  @network_access_management_updateTrustDomainDevice_01_rename_success @basic_tier
+  Scenario: Update the deviceName of a registered device
+    Given the request body property "$.deviceName" is set to "Living Room Thermostat"
+    When the request "updateTrustDomainDevice" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
+    And the response property "$.id" equals the path parameter "deviceId"
+    And the response property "$.deviceName" is "Living Room Thermostat"
+
+  @network_access_management_updateTrustDomainDevice_02_replace_credential_success @basic_tier
+  Scenario: Replace the deviceCredential on a registered device (full-replacement semantics)
+    Given the request body property "$.deviceCredential" is set to a valid DeviceCredential with credentialAction "GENERATE"
+    When the request "updateTrustDomainDevice" is sent
+    Then the response status code is 200
+    And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
+    And the response property "$.modifiedAt" is a valid RFC 3339 date-time with timezone
+    And the response body does not echo back the request body property "$.deviceCredential.value"

--- a/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
@@ -39,4 +39,4 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomai
     Then the response status code is 200
     And the response body complies with the OAS schema at "/components/schemas/TrustDomainDevice"
     And the response property "$.modifiedAt" is a valid RFC 3339 date-time with timezone
-    And the response body does not echo back the request body property "$.deviceCredential.value"
+    And the response body does not contain the property "$.deviceCredential.value"

--- a/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
@@ -1,4 +1,4 @@
-@basic_tier
+  @basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomainDevice
   # Operation: PATCH /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices

--- a/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
+++ b/code/Test_definitions/network-access-management-updateTrustDomainDevice.feature
@@ -1,3 +1,4 @@
+@basic_tier
 Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomainDevice
   # Operation: PATCH /trust-domains/{trustDomainId}/devices/{deviceId}
   # Required scope: network-access-management:devices
@@ -20,7 +21,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomai
     And the path parameter "trustDomainId" is set to the id of a Trust Domain created by the calling API client
     And the path parameter "deviceId" is set to the id of a device registered to that Trust Domain
 
-  @network_access_management_updateTrustDomainDevice_01_rename_success @basic_tier
+  @network_access_management_updateTrustDomainDevice_01_rename_success
   Scenario: Update the deviceName of a registered device
     Given the request body property "$.deviceName" is set to "Living Room Thermostat"
     When the request "updateTrustDomainDevice" is sent
@@ -31,7 +32,7 @@ Feature: CAMARA Network Access Management API, vwip - Operation updateTrustDomai
     And the response property "$.id" equals the path parameter "deviceId"
     And the response property "$.deviceName" is "Living Room Thermostat"
 
-  @network_access_management_updateTrustDomainDevice_02_replace_credential_success @basic_tier
+  @network_access_management_updateTrustDomainDevice_02_replace_credential_success
   Scenario: Replace the deviceCredential on a registered device (full-replacement semantics)
     Given the request body property "$.deviceCredential" is set to a valid DeviceCredential with credentialAction "GENERATE"
     When the request "updateTrustDomainDevice" is sent


### PR DESCRIPTION
#### What type of PR is this?

* tests

#### What this PR does / why we need it:

Adds the initial set of Gherkin test definitions for the Network Access Management API — one `.feature` file per `operationId` (20 files total) under `code/Test_definitions/`. This is the first concrete step toward satisfying row 7 ("Basic API test cases & documentation") of the API Readiness Checklist, which is mandatory at release-candidate and beyond.

`network-access-management-createTrustDomain.feature` is authored at the **full tier** as the canonical exemplar — sunny-day scenarios for each `accessDetails` discriminator variant plus the documented 400 / 401 / 403 / 409 error matrix. The remaining 19 files are authored at the **basic tier** (sunny-day + schema validation only), which is the bar for the release-candidate gate. Full-tier (rainy-day) expansion of the other 19 is tracked as a follow-up workstream against the public-release gate.

The suite follows the conventions in the Commonalities [`API-Testing-Guidelines.md`](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-Testing-Guidelines.md) and mirrors the structure used in the QualityOnDemand reference suite (one file per `operationId`, `@<api>_<operationId>_NN_<slug>` tag pattern, runner-agnostic step phrasing referencing the OAS by `operationId` and JSON Pointer). All 20 files parse cleanly through `@cucumber/gherkin-utils`.

`code/Test_definitions/README.md` is updated with the conventions, tier definitions, file inventory, runner-execution notes, and authoring guidance pointing back at the pilot.

#### Which issue(s) this PR fixes:

Fixes #52

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This PR only adds artifacts under `code/Test_definitions/`. No changes to the API specification, no changes to schemas, no changes to existing modules.

#### Special notes for reviewers:

Conventions adopted in this PR:

- **Filename**: `network-access-management-{operationId}.feature`, one per `operationId`.
- **Tagging**:
  - `@network_access_management_{operationId}_{NN}_{slug}` — unique scenario id.
  - `@basic_tier` / `@full_tier` — coverage tier (per the Commonalities testing guidelines).
  - `@requires_oidc` — scenario depends on real OIDC enforcement and should auto-skip in environments without an OIDC server.
  - `@backend_controlled` — scenario depends on backend state a thin facade may not be able to drive directly (e.g. 409 conflicts).
- **Schema references** use JSON Pointers into the bundled OAS (`/components/schemas/...`), not into modular files. Runners need to bundle (`redocly bundle`) before resolving.
- **Background block** for every file: `apiRoot` + resource + `Content-Type` + `Authorization` (with required scope assertion) + `x-correlator` schema check + (for write ops) default-valid request body.

The `createTrustDomain` pilot is intentionally over-scoped (full tier) so it can act as the exemplar for the eventual full-tier fan-out — every other file is a strict subset of its structure.

This PR does not introduce a runner harness; per CAMARA convention, the `.feature` files are declarative artifacts that consuming organizations exercise with their own glue (Behave, pytest-bdd, Karate, etc.).

#### Changelog input

```
release-note
Adds initial Gherkin test definitions for all 20 NAM operations: the createTrustDomain pilot at full tier and the remaining 19 at basic tier, with conventions documented in code/Test_definitions/README.md.
```


#### Additional documentation

```
docs
code/Test_definitions/README.md — file naming and tagging conventions, coverage tiers, runner-execution notes, authoring guidance.
````