### PR TITLE
Feat/wkso bootstrapping

### DIFF
--- a/code/API_definitions/README.md
+++ b/code/API_definitions/README.md
@@ -19,7 +19,7 @@ code/
 ├── common/
 │   └── CAMARA_common.yaml                       # Local cached copy of the Commonalities shared error responses
 └── modules/                                     # Modular domain-focused component files
-    ├── NAM_Common.yaml                          # Shared primitives (UUID, DateTime, ResourceAudit, securitySchemes)
+    ├── NAM_Common.yaml                          # Shared primitives (UUID, DateTime, PropertyAddress, ResourceIdentifier, securitySchemes)
     ├── AccessDetail.yaml                        # Discriminated access detail variants (Wi-Fi, Thread)
     ├── Policy.yaml                              # Trust Domain policy schemas (maxDevices, bandwidth, egress)
     ├── NetworkAccessDevices/                    # Network Access Device resource schemas
@@ -53,10 +53,11 @@ code/
 
 | File | Purpose | Reusability |
 |------|---------|-------------|
-| `Common.yaml` | Base types (UUID, DateTime, ErrorInfo) | High - used across all APIs |
-| `Policy.yaml` | Trust Domain governance policies | Medium - Trust Domain specific |
-| `AccessDetail.yaml` | Network access configurations | Medium - Network-related APIs |
-| `TrustDomains.yaml` | Core Trust Domain schemas | Low - Trust Domain specific |
+| `CAMARA_common.yaml` | CAMARA-wide error responses and shared schemas (cached from Commonalities) | High — required by every CAMARA API |
+| `NAM_Common.yaml` | NAM-wide primitives (UUID, DateTime, PropertyAddress, ResourceIdentifier, securitySchemes) | High — used across all NAM endpoints |
+| `Policy.yaml` | Trust Domain governance policies | Medium — Trust Domain specific |
+| `AccessDetail.yaml` | Network access configurations | Medium — Network-related schemas |
+| `TrustDomains.yaml` | Core Trust Domain schemas | Low — Trust Domain specific |
 
 ## Bundling and Validation
 

--- a/code/API_definitions/network-access-management.yaml
+++ b/code/API_definitions/network-access-management.yaml
@@ -6,7 +6,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.8.0-rc.2
   description: |
     Service enabling API for managing network operator supplied network access devices. This API's initial focus is on
     managing **Trust Domains** and device reboot requests.

--- a/code/modules/TrustDomainDevices/TrustDomainDevices.yaml
+++ b/code/modules/TrustDomainDevices/TrustDomainDevices.yaml
@@ -78,6 +78,7 @@ components:
       enum:
         - DPP
         - MATTER
+        - WKSO
 
     DppBootstrappingConfig:
       type: object
@@ -124,11 +125,41 @@ components:
             See Matter Core Specification Section 5.1.3 for payload structure details.
           example: "MT:Y3.13OTB00KA0648G00"
 
+    WksoBootstrappingConfig:
+      type: object
+      description: |
+        Well-Known SSID Onboarding (WKSO) bootstrapping configuration. The device
+        connects to a well-known SSID and presents a client certificate; the operator
+        uses identity material extracted from the certificate to look up and
+        authorize the device on the Trust Domain.
+
+        **Note:** The exact `bootstrappingUri` shape is provisional and
+        implementation-specific. WKSO is not yet standardized; the format below
+        reflects an initial proof-of-concept convention and is expected to evolve —
+        for example, future iterations may incorporate cryptographically verifiable
+        fields analogous to those carried in DPP bootstrapping URIs.
+      required:
+        - bootstrappingUri
+      properties:
+        bootstrappingUri:
+          type: string
+          maxLength: 2048
+          description: |
+            A WKSO bootstrapping URI carrying the identity material the operator
+            uses to locate and authenticate the device.
+
+            Format is provisional and may change as WKSO is standardized. The
+            current proof-of-concept convention encodes the device's Organizational
+            Unit (OU) and Serial Number (SN) from the client certificate subject,
+            expressed as semicolon-delimited key-value pairs. This shape is
+            illustrative rather than normative.
+          example: "WKS:OU:00405E;SN:rpi-client-1;;"
+
     BootstrappingInfo:
       type: object
       description: |
         Provisioning protocol configurations for onboarding a device to the Trust Domain.
-        Each protocol property (DPP, MATTER) represents a supported bootstrapping protocol
+        Each protocol property (DPP, MATTER, WKSO) represents a supported bootstrapping protocol
         and its configuration. A device may support multiple protocols simultaneously.
 
         When multiple protocols are configured, use `protocolPreference` to indicate the
@@ -162,6 +193,8 @@ components:
           $ref: "#/components/schemas/DppBootstrappingConfig"
         MATTER:
           $ref: "#/components/schemas/MatterBootstrappingConfig"
+        WKSO:
+          $ref: "#/components/schemas/WksoBootstrappingConfig"
 
     CredentialType:
       type: string


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds **WKSO (Well-Known SSID Onboarding)** as a third Trust Domain Device bootstrapping protocol alongside the existing **DPP** and **MATTER**. The flow: a device connects to a well-known SSID and presents a client certificate; the operator extracts identity material from the certificate subject to look up and authorize the device on the Trust Domain.

Mechanically, this introduces in [code/modules/TrustDomainDevices/TrustDomainDevices.yaml](code/modules/TrustDomainDevices/TrustDomainDevices.yaml):
- A `WKSO` enum value on `BootstrappingProtocol`
- A new `WksoBootstrappingConfig` schema (sibling of `DppBootstrappingConfig` and `MatterBootstrappingConfig`)
- A `WKSO` property on `BootstrappingInfo` referencing the new schema
- A description tweak to `BootstrappingInfo` so the protocol-list reads `(DPP, MATTER, WKSO)`

The `bootstrappingUri` description is intentionally hedged: WKSO does not yet have a public standard, and the current shape (`WKS:OU:...;SN:...;;`) reflects a proof-of-concept convention that is expected to evolve — possibly toward a cryptographically verifiable encoding similar to DPP. The schema reserves the slot without locking the wire format.

This PR also bumps **`x-camara-commonalities` from `0.6` to `0.8.0-rc.2`** in [code/API_definitions/network-access-management.yaml](code/API_definitions/network-access-management.yaml) so the API declares compliance with the upcoming Commonalities r4.2 dependency. The matching `release-plan.yaml` change lands in a separate follow-up PR — the central CAMARA PR validation enforces `release-plan.yaml` exclusivity, so the spec-side and plan-side companion changes cannot share a PR. Landing the header bump here, on the last API-content PR before release-plan moves, keeps the spec aligned with the about-to-be-declared dependency and avoids a transient inconsistency that would surface when the release-plan PR later triggers downstream automation.

A small **README staleness cleanup** is also included in [code/API_definitions/README.md](code/API_definitions/README.md): it should have ridden with #121 (correcting a `Common.yaml` reference to `NAM_Common.yaml` and replacing a wrong contents list with the accurate one), but the cleanup commit was authored locally after #121 was already squash-merged.

#### Which issue(s) this PR fixes:

N/A — no dedicated tracking issue.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

All schema changes are additive: a new enum value, a new schema, a new optional property under `BootstrappingInfo`. Existing API consumers using DPP or MATTER are unaffected; the bundled spec for those flows resolves identically to before. The `x-camara-commonalities` bump is a metadata declaration with no effect on the wire format. The README change is docs-only.

#### Special notes for reviewers:

- **WKSO URI format is provisional.** Unlike DPP (Wi-Fi Alliance spec) and Matter (CSA spec), WKSO has no public normative reference yet — the schema description flags this explicitly. No `externalDocs` link until standardization solidifies. Reviewers may want to refine the wording further; the principle to preserve is that the schema reserves the slot without prescribing its wire format.
- **No `TrustDomainDeviceCreateWkso` example** is wired into [network-access-management.yaml](code/API_definitions/network-access-management.yaml). Adding one is reasonable but optional given WKSO's provisional status — happy to add during review if reviewers want it.
- **Verification.** `redocly lint` passes. Bundle diff vs `camara/main` is exactly: the `x-camara-commonalities` header line + the WKSO additions (enum value, new schema, BootstrappingInfo description tweak, WKSO property reference). No semantic drift in any other path.
- **Companion PR coming.** A follow-up PR will modify only `release-plan.yaml` (`target_release_type: pre-release-rc`, `dependencies.commonalities_release: r3.4 → r4.2`, real API entry) — kept separate to comply with the central PR validation's release-plan exclusivity rule.

#### Changelog input

```
release-note

Added WKSO (Well-Known SSID Onboarding) as a supported Trust Domain Device bootstrapping protocol alongside DPP and MATTER. The bootstrappingUri format is provisional and expected to evolve as WKSO is standardized.
Updated declared Commonalities compliance: x-camara-commonalities: 0.6 → 0.8.0-rc.2 (paired with a separate release-plan.yaml PR bumping dependencies.commonalities_release to r4.2).
```

#### Additional documentation

```
docs

code/API_definitions/README.md: corrected stale Component Breakdown table entry (Common.yaml → NAM_Common.yaml) and replaced its wrong contents list with the accurate set. Pre-existing inaccuracy that should have ridden with #121.
```