### PR TITLE
Plan release r2.1 with API network-access-management alpha 0.2.0

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,26 +16,26 @@ repository:
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.1
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # Replace the placeholder below when planning a release:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
-  - api_name: placeholder-entry
-    target_api_version: 0.1.0
-    target_api_status: draft
+  - api_name: network-access-management
+    target_api_version: 0.2.0
+    target_api_status: alpha
     main_contacts:
       - caubut-charter
       - mayur007


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Updates `release-plan.yaml` to plan release **r2.1** as a `pre-release-alpha` of `network-access-management` at version `0.2.0`, with dependencies on Commonalities **r4.2** and ICM **r4.2**.

This implements the redirect proposed in #34: leaving the unfinished 0.1.0 / r1.x line behind and starting a fresh r2.1 cycle on the new release automation, validation and bundling.

#### Which issue(s) this PR fixes:

Fixes #34

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Plan-only change; no API surface modified.

#### Special notes for reviewers:

- Scope intentionally limited to `release-plan.yaml` to comply with the central CAMARA release-plan exclusivity rule.
- **Recommended merge sequence: #125 (workflow enablement) → this PR → Common Sync PR.** While `apis[0]` is `placeholder-entry` / `draft`, the central CAMARA Validation has no API to resolve — see the validation run on #125 (https://github.com/camaraproject/NetworkAccessManagement/actions/runs/25598682022): all green but no real spec linted. Landing this PR right after #125 puts every subsequent PR under r4.x validation against the real API; the Common Sync PR then brings `code/common/` to the official r4.2 state. Subsequent PRs are sequenced by the codeowners based on validation findings.

#### Changelog input

```
release-note

NONE
```

#### Additional documentation

```
docs

NONE
```
