### PR TITLE
fix: pin validation caller to tooling S-037 hotfix SHA

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -30,5 +30,9 @@ permissions:
 
 jobs:
   validation:
-    uses: camaraproject/tooling/.github/workflows/validation.yml@v1-rc
+    # Temporary pin to the tooling S-037 hotfix (camaraproject/tooling#284).
+    # Revert to @v1-rc + drop the with: block once @v1-rc advances past this SHA.
+    uses: camaraproject/tooling/.github/workflows/validation.yml@2a6dc66c4cabc48716c165a612a13985d93a5bf4
+    with:
+      tooling_ref_override: "2a6dc66c4cabc48716c165a612a13985d93a5bf4"
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

Pins NAM's CAMARA Validation caller to the tooling S-037 hotfix SHA (`2a6dc66c4cabc48716c165a612a13985d93a5bf4`), consuming [camaraproject/tooling#284](https://github.com/camaraproject/tooling/pull/284) ahead of the next `@v1-rc` advance. Unblocks `/create-snapshot` for r2.1 alpha without modifying the `ServiceId` schema.

`uses:` pins the reusable workflow itself; `tooling_ref_override` pins the script checkout — both must point at the same SHA for end-to-end consumption of the hotfix.

The pin is temporary. Revert to `@v1-rc` and drop the `with:` block once `@v1-rc` advances past the hotfix commit.

#### Which issue(s) this PR fixes:

Fixes #137

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

* Alternative to the spec-side fix outlined in #137 (drop the `allOf` wrapper). Either path unblocks r2.1 alpha; this one preserves the `ServiceId` schema shape and its description.
* Pinned SHA stays reachable on `camaraproject/tooling` through merge into `main` and after the hotfix branch is deleted.
* Sequence to unblock r2.1: merge this PR → `/discard-snapshot` on #132 → `/create-snapshot`.

#### Changelog input

```
 release-note

```

#### Additional documentation 

```
docs

```
