### PR TITLE
chore: revert validation caller to @v1-rc

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -30,9 +30,5 @@ permissions:
 
 jobs:
   validation:
-    # Temporary pin to the tooling S-037 hotfix (camaraproject/tooling#284).
-    # Revert to @v1-rc + drop the with: block once @v1-rc advances past this SHA.
-    uses: camaraproject/tooling/.github/workflows/validation.yml@2a6dc66c4cabc48716c165a612a13985d93a5bf4
-    with:
-      tooling_ref_override: "2a6dc66c4cabc48716c165a612a13985d93a5bf4"
+    uses: camaraproject/tooling/.github/workflows/validation.yml@v1-rc
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Revert the temporary tooling pin added by #138. `@v1-rc` has advanced and now includes the S-037 hotfix commit; the `uses:`-SHA and `tooling_ref_override:` are no longer needed.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Two-line revert.

#### Changelog input

```
 release-note
none
```

#### Additional documentation

This section can be blank.

```
docs

```
