### PR TITLE
docs: add 400 input-validation responses to read/delete operations (#133)

### DIFF
--- a/code/API_definitions/network-access-management.yaml
+++ b/code/API_definitions/network-access-management.yaml
@@ -219,6 +219,8 @@ paths:
             application/json:
               schema:
                 $ref: "../modules/Services/Services.yaml#/components/schemas/ServiceList"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -264,6 +266,8 @@ paths:
             application/json:
               schema:
                 $ref: "../modules/Services/Services.yaml#/components/schemas/Service"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -304,6 +308,8 @@ paths:
             application/json:
               schema:
                 $ref: "../modules/TrustDomains/TrustDomainCapabilities.yaml#/components/schemas/TrustDomainCapabilities"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -394,6 +400,8 @@ paths:
                 type: array
                 items:
                   $ref: "../modules/TrustDomains/TrustDomains.yaml#/components/schemas/TrustDomain"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -433,6 +441,8 @@ paths:
               examples:
                 TrustDomainResponseBasic:
                   $ref: '../modules/TrustDomains/TrustDomains.yaml#/components/examples/TrustDomainResponseBasic'
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -496,6 +506,8 @@ paths:
       responses:
         "204":
           description: Trust Domain deleted successfully
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -582,6 +594,8 @@ paths:
               examples:
                 TrustDomainDeviceListResponse:
                   $ref: '../modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceListResponse'
+        '400':
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -618,6 +632,8 @@ paths:
               examples:
                 TrustDomainDeviceResponseConnected:
                   $ref: '../modules/TrustDomainDevices/TrustDomainDevices.yaml#/components/examples/TrustDomainDeviceResponseConnected'
+        '400':
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -680,6 +696,8 @@ paths:
       responses:
         '204':
           description: Device removed successfully
+        '400':
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -709,6 +727,8 @@ paths:
             application/json:
               schema:
                 $ref: "../modules/NetworkAccessDevices/NetworkAccessDevices.yaml#/components/schemas/NetworkAccessDeviceList"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -740,6 +760,8 @@ paths:
             application/json:
               schema:
                 $ref: "../modules/NetworkAccessDevices/NetworkAccessDevices.yaml#/components/schemas/NetworkAccessDevice"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -848,6 +870,8 @@ paths:
                 type: array
                 items:
                   $ref: '../modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
+        '400':
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -878,6 +902,8 @@ paths:
             application/json:
               schema:
                 $ref: '../modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
+        '400':
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':
@@ -942,6 +968,8 @@ paths:
       responses:
         '204':
           description: Reboot Request deleted successfully
+        '400':
+          $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
         '403':


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Adds a `400` input-validation response to every read (`GET`) and delete (`DELETE`) operation that accepts path or query parameters. The CAMARA Validation Framework raised 14 `S-318` (`owasp:api8:2023-define-error-validation`) warnings on PR #131 because these operations declared only auth/resource errors (401/403/404), not a 400/422 input-validation error. Path/query parameters (UUID-typed `{trustDomainId}`, `{deviceId}`, `{rebootRequestId}`, etc.) can fail format validation before auth/resource checks run, so each operation now references the shared `Generic400`.

The 14 operations: `GET /services`, `GET /services/{serviceId}`, `GET /trust-domains/capabilities`, `GET /trust-domains`, `GET`+`DELETE /trust-domains/{trustDomainId}`, `GET /trust-domains/{trustDomainId}/devices`, `GET`+`DELETE /trust-domains/{trustDomainId}/devices/{deviceId}`, `GET /network-access-devices`, `GET /network-access-devices/{networkAccessDeviceId}`, `GET /reboot-requests`, `GET`+`DELETE /reboot-requests/{rebootRequestId}`.

Mechanical change; single file (`code/API_definitions/network-access-management.yaml`); 14 additions, each matching the surrounding block's quote style. `redocly lint` passes.

#### Which issue(s) this PR fixes:

Fixes #133

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

The 400-vs-422 boundary (which class of input error returns which code) is the deeper question tracked in #129; this PR is the prerequisite — ensuring every read/delete declares a 400 at all.

#### Changelog input

```
 release-note
Added 400 (Generic400) input-validation responses to all GET/DELETE operations.
```

#### Additional documentation

This section can be blank.

```
docs

```
