### PR TITLE
docs: tighten integer format/bounds and string maxLengths (#135)

### DIFF
--- a/code/modules/AccessDetail.yaml
+++ b/code/modules/AccessDetail.yaml
@@ -141,6 +141,7 @@ components:
           example: "Thread:STRUCTURED"
         channel:
           type: integer
+          format: int32
           minimum: 11
           maximum: 26
           description: The Thread channel (IEEE 802.15.4 channel number)
@@ -148,11 +149,13 @@ components:
         extendedPanId:
           type: string
           pattern: "^[0-9a-fA-F]{16}$"
+          maxLength: 16
           description: The Extended PAN ID (16 hex digits)
           example: "d63e8e3e495ebbc3"
         networkKey:
           type: string
           pattern: "^[0-9a-fA-F]{32}$"
+          maxLength: 32
           description: The Thread Network Key (32 hex digits)
           example: "dfd34f0f05cad978ec4e32b0413038ff"
         networkName:
@@ -164,6 +167,7 @@ components:
         panId:
           type: string
           pattern: "^[0-9a-fA-F]{4}$"
+          maxLength: 4
           description: The PAN ID (4 hex digits)
           example: "d63e"
       additionalProperties: false

--- a/code/modules/NAM_Common.yaml
+++ b/code/modules/NAM_Common.yaml
@@ -35,6 +35,7 @@ components:
     DateTime:
       type: string
       format: date-time
+      maxLength: 64
       description: |
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
         Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or

--- a/code/modules/NetworkAccessDevices/NetworkAccessDevices.yaml
+++ b/code/modules/NetworkAccessDevices/NetworkAccessDevices.yaml
@@ -81,6 +81,7 @@ components:
                     value:
                       type: string
                       pattern: "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+                      maxLength: 17
                       example: &device-hardware-address-value "12:34:56:78:9A:BC"
                   required:
                     - hardwareAddressType

--- a/code/modules/Policy.yaml
+++ b/code/modules/Policy.yaml
@@ -30,7 +30,9 @@ components:
 
     MaxDevicesPolicy:
       type: integer
+      format: int32
       minimum: 1
+      maximum: 1024
       description: Limits the number of devices that may join the Trust Domain.
       example: 10
 
@@ -39,6 +41,9 @@ components:
       properties:
         value:
           type: integer
+          format: int64
+          minimum: 0
+          maximum: 10000000
           description: Maximum downstream throughput across the domain.
         unit:
           type: string
@@ -57,6 +62,9 @@ components:
       properties:
         value:
           type: integer
+          format: int64
+          minimum: 0
+          maximum: 10000000
           description: Maximum upstream throughput across the domain.
         unit:
           type: string
@@ -74,6 +82,7 @@ components:
       type: array
       items:
         type: string
+        maxLength: 253
         description: FQDN or CIDR pattern
       minItems: 1
       description: Restricts egress traffic to the specified destinations.

--- a/code/modules/TrustDomainDevices/TrustDomainDevices.yaml
+++ b/code/modules/TrustDomainDevices/TrustDomainDevices.yaml
@@ -327,6 +327,7 @@ components:
             value:
               type: string
               pattern: "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+              maxLength: 17
               description: The hardware address value in the format specified by hardwareAddressType.
               example: "AA:BB:CC:DD:EE:F1"
           required:

--- a/code/modules/TrustDomains/TrustDomainCapabilities.yaml
+++ b/code/modules/TrustDomains/TrustDomainCapabilities.yaml
@@ -129,12 +129,16 @@ components:
       properties:
         maxValue:
           type: integer
+          format: int32
           minimum: 1
+          maximum: 1024
           description: Maximum number of devices allowed
           example: 100
         minValue:
           type: integer
+          format: int32
           minimum: 1
+          maximum: 1024
           description: Minimum number of devices allowed
           example: 1
       required:
@@ -147,12 +151,16 @@ components:
       properties:
         maxValue:
           type: integer
-          minimum: 1
+          format: int64
+          minimum: 0
+          maximum: 10000000000
           description: Maximum bandwidth value in bits per second
           example: 1000000000
         minValue:
           type: integer
-          minimum: 1
+          format: int64
+          minimum: 0
+          maximum: 10000000000
           description: Minimum bandwidth value in bits per second
           example: 1000000
       required:
@@ -165,7 +173,9 @@ components:
       properties:
         maxEntries:
           type: integer
+          format: int32
           minimum: 1
+          maximum: 1024
           description: Maximum number of allowed egress destinations
           example: 50
         supportedDestinationTypes:
@@ -216,12 +226,14 @@ components:
           properties:
             min:
               type: integer
+              format: int32
               minimum: 11
               maximum: 26
               description: Minimum supported Thread channel
               example: 11
             max:
               type: integer
+              format: int32
               minimum: 11
               maximum: 26
               description: Maximum supported Thread channel
@@ -240,11 +252,15 @@ components:
           properties:
             minLength:
               type: integer
+              format: int32
               minimum: 1
+              maximum: 16
               example: 1
             maxLength:
               type: integer
+              format: int32
               minimum: 1
+              maximum: 16
               example: 16
           required:
             - minLength
@@ -252,9 +268,11 @@ components:
           description: Constraints on Thread network names
         maxDatasetLength:
           type: integer
+          format: int32
           minimum: 1
+          maximum: 254
           description: Maximum length for TLV operational dataset (applies to Thread:TLV)
-          example: 255
+          example: 254
       description: Thread specific access type properties
 
     PasswordConstraints:
@@ -262,12 +280,16 @@ components:
       properties:
         minLength:
           type: integer
+          format: int32
           minimum: 8
+          maximum: 63
           description: Minimum password length
           example: 8
         maxLength:
           type: integer
-          minimum: 1
+          format: int32
+          minimum: 8
+          maximum: 63
           description: Maximum password length
           example: 63
         requireSpecialCharacters:

--- a/code/modules/TrustDomains/TrustDomains.yaml
+++ b/code/modules/TrustDomains/TrustDomains.yaml
@@ -75,10 +75,12 @@ components:
       properties:
         name:
           type: string
+          maxLength: 64
           description: Human-readable name for the trust domain.
           example: "Primary WiFi Network"
         description:
           type: string
+          maxLength: 255
           description: Detailed description of the trust domain.
           example: "Primary home WiFi Network for all devices"
         enabled:


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Adds the field constraints required by [CAMARA API Design Guide §2.2](https://github.com/camaraproject/Commonalities/blob/r4.3/documentation/CAMARA-API-Design-Guide.md#22-data) to module schemas. The CAMARA Validation Framework raised 32 hints on PR #131:

- **S-310** (`owasp:api4:2023-integer-format`) — integers missing `format: int32`/`int64`
- **S-311** (`owasp:api4:2023-integer-limit-legacy`) — integers missing `minimum`/`maximum`
- **S-312** (`owasp:api4:2023-string-limit`) — bounded strings missing `maxLength`

Integer properties now declare `format` plus `minimum`/`maximum`; bounded string properties declare `maxLength`. Touches `code/modules/`: `Policy.yaml`, `TrustDomains/TrustDomainCapabilities.yaml`, `AccessDetail.yaml`, `NAM_Common.yaml`, `NetworkAccessDevices/NetworkAccessDevices.yaml`, `TrustDomainDevices/TrustDomainDevices.yaml`, `TrustDomains/TrustDomains.yaml`. `redocly lint` passes.

#### Which issue(s) this PR fixes:

Fixes #135

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Values follow the issue's proposed table **except two deviations** flagged for review:

1. **`DateTime` `maxLength` = 64, not the issue's 30.** 30 is too short for RFC 3339 with sub-second precision and a timezone offset (e.g. `2023-07-03T14:27:08.312456+02:00` = 32 chars), and 64 matches the Commonalities canonical `DateTime`. Aligning avoids drift from the shared definition.
2. **`BandwidthPolicyCapability.maxValue`/`minValue` `maximum` = 10000000000 (10 Gbps in bits/sec), not the issue's 10000000.** This capability is documented in **bits per second** (existing example `1000000000` = 1 Gbps), unlike the Kbps-based rate policies in `Policy.yaml` where 10000000 (= 10 Gbps in Kbps) is correct. The issue's rationale assumed Kbps; applying 10000000 here would reject the existing 1 Gbps example. Also bumped `maxDatasetLength` example `255` → `254` to conform to the proposed `maximum: 254`.

The `maxLength` added to the four pattern-constrained hex/MAC strings (`extendedPanId`, `networkKey`, `panId`, `hardwareAddress.value`) is redundant with their existing regex but clears the S-312 hint, per discussion.

`maxItems` on arrays is intentionally out of scope (tracked in #130).

#### Changelog input

```
 release-note
Added integer format/min/max and string maxLength constraints across module schemas (CAMARA Design Guide §2.2).
```

#### Additional documentation

This section can be blank.

```
docs

```
