### PR TITLE
docs: add Rich Woundy to MAINTAINERS.MD (#142)

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -5,3 +5,4 @@
 | Vodafone | Mayur Channegowda | mayur007 |
 | CableLabs | Ben Hepworth | benhepworth |
 | CableLabs | Cody Lundie | clundie-CL |
+| Comcast | Rich Woundy | RICH-WOUNDY-USERNAME |

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -5,4 +5,4 @@
 | Vodafone | Mayur Channegowda | mayur007 |
 | CableLabs | Ben Hepworth | benhepworth |
 | CableLabs | Cody Lundie | clundie-CL |
-| Comcast | Rich Woundy | RICH-WOUNDY-USERNAME |
+| Comcast | Rich Woundy | rwound00_comcast |

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -5,4 +5,4 @@
 | Vodafone | Mayur Channegowda | mayur007 |
 | CableLabs | Ben Hepworth | benhepworth |
 | CableLabs | Cody Lundie | clundie-CL |
-| Comcast | Rich Woundy | rwound00_comcast |
+| Comcast | Rich Woundy | rwoundy |


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Adds **Rich Woundy (Comcast)** to `MAINTAINERS.MD`, per #142.

Scope is limited to `MAINTAINERS.MD`. `CODEOWNERS` is intentionally **not** modified in this PR (per maintainer direction), even though #142's title mentions both lists.

#### Which issue(s) this PR fixes:

Fixes #142

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

- `MAINTAINERS.MD` is owned by `@camaraproject/admins` (see `CODEOWNERS`), so this PR will require admin approval to merge.

#### Changelog input

```
 release-note
Added Rich Woundy (Comcast) to the maintainers list.
```

#### Additional documentation

This section can be blank.

```
docs

```
