### PR TITLE
chore: declare split APIs (network-access-devices, network-access-domains) in release-plan as draft (#152)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -33,9 +33,17 @@ dependencies:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
-  - api_name: network-access-management
+  - api_name: network-access-devices
     target_api_version: 0.3.0
-    target_api_status: rc
+    target_api_status: draft
+    main_contacts:
+      - caubut-charter
+      - mayur007
+      - clundie-CL
+      - benhepworth
+  - api_name: network-access-domains
+    target_api_version: 0.3.0
+    target_api_status: draft
     main_contacts:
       - caubut-charter
       - mayur007

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: none
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -33,6 +33,14 @@ dependencies:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
+  - api_name: network-access-management
+    target_api_version: 0.3.0
+    target_api_status: draft
+    main_contacts:
+      - caubut-charter
+      - mayur007
+      - clundie-CL
+      - benhepworth
   - api_name: network-access-devices
     target_api_version: 0.3.0
     target_api_status: draft


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

First step of the sequenced API split (see #153), per @hdamker's "draft status" guidance for the release-plan hen-egg. It declares the split API names in `release-plan.yaml` so the restructure PR can add the matching spec files without tripping validation.

Two adjustments are needed to keep this PR's validation **clean (0 errors)**:

1. **All entries are `target_api_status: draft`** — draft allows the spec YAML to not exist yet (no `P-002` error). This includes keeping **`network-access-management`** as a transitional draft entry: with its `network-access-management.yaml` still present, dropping it from the plan would make the file an *orphan* and trip `P-009`'s "naming mismatch" (which the released tooling treats as blocking). Declaring it keeps the plan and the on-disk file consistent.
2. **`target_release_type: none`** (parked) — `P-009` rejects `draft` APIs while the repo targets `pre-release-rc`. Parking the plan is the supported state while the restructure is in flight.

Sequence:
1. **(this PR)** declare all three APIs as `draft`, park the release type.
2. **#153** adds `network-access-devices.yaml` + `network-access-domains.yaml` and deletes `network-access-management.yaml`, with **no** `release-plan.yaml` change (so it isn't blocked by `P-022`).
3. **rc-bump PR** drops the `network-access-management` entry, sets `network-access-devices` + `network-access-domains` to `rc`, and restores `target_release_type: pre-release-rc` for the r3.1 cut.

Relates to #152; unblocks #153.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

(Release-plan declaration only — no API surface change here. The split itself, in #153, is the breaking change.)

#### Special notes for reviewers:

- **Validation passes** (0 errors). Remaining findings are non-blocking warnings/hints carried by the existing spec (e.g. `S-309` array `maxItems`, `P-006` test files, `P-032` legacy readiness checklist) — addressed in #153 / tracked separately.
- **Merge order:** this PR should merge **before** #153.
- **`target_api_version`** carried over as `0.3.0` to stay aligned with the repo's r3.1 target — flagging for release-management confirmation in case fresh `0.1.0` numbering is preferred for the new api_names.

#### Changelog input

```
 release-note

```
