### PR TITLE
fix: clear r4.3 validation warnings — maxItems + info.description templates (#155)

### DIFF
--- a/code/API_definitions/network-access-devices.yaml
+++ b/code/API_definitions/network-access-devices.yaml
@@ -322,6 +322,7 @@ paths:
                 type: array
                 items:
                   $ref: '../modules/RebootRequests/RebootRequests.yaml#/components/schemas/RebootRequest'
+                maxItems: 100
         '400':
           $ref: '../common/CAMARA_common.yaml#/components/responses/Generic400'
         '401':

--- a/code/API_definitions/network-access-devices.yaml
+++ b/code/API_definitions/network-access-devices.yaml
@@ -41,13 +41,15 @@ info:
     # API Functionality
     This API allows API Consumers to retrieve Network Access Devices and create reboot requests against them.
 
-    ### Authorization and authentication
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+    # Authorization and authentication
 
-    The "CAMARA Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
+    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     ### Scopes
     Scopes are used to protect the service owner's information and privacy.  The general format is
@@ -133,13 +135,21 @@ info:
     device representing this mesh.  Alternatively, a synthetic hardware address may also be used if the specification
     for the address type allows.
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/code/API_definitions/network-access-domains.yaml
+++ b/code/API_definitions/network-access-domains.yaml
@@ -334,6 +334,7 @@ paths:
                 type: array
                 items:
                   $ref: "../modules/TrustDomains/TrustDomains.yaml#/components/schemas/TrustDomain"
+                maxItems: 100
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/network-access-domains.yaml
+++ b/code/API_definitions/network-access-domains.yaml
@@ -45,13 +45,15 @@ info:
     # API Functionality
     This API allows API Consumers to manage Trust Domains and register subscriber/IoT devices within them.
 
-    ### Authorization and authentication
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+    # Authorization and authentication
 
-    The "CAMARA Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
+    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     ### Scopes
     Scopes are used to protect the service owner's information and privacy.  The general format is
@@ -97,13 +99,21 @@ info:
     device representing this mesh.  Alternatively, a synthetic hardware address may also be used if the specification
     for the address type allows.
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
+
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+    # Request body strictness
+
+    This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/code/modules/NetworkAccessDevices/NetworkAccessDevices.yaml
+++ b/code/modules/NetworkAccessDevices/NetworkAccessDevices.yaml
@@ -117,6 +117,7 @@ components:
       description: A list of network access devices.
       items:
         $ref: "#/components/schemas/NetworkAccessDevice"
+      maxItems: 100
       example: &device-list
         - *device
         - id: *uuid-example-2

--- a/code/modules/Policy.yaml
+++ b/code/modules/Policy.yaml
@@ -85,6 +85,7 @@ components:
         maxLength: 253
         description: FQDN or CIDR pattern
       minItems: 1
+      maxItems: 1024
       description: Restricts egress traffic to the specified destinations.
       example:
         - "api.vendor.com"

--- a/code/modules/RebootRequests/RebootRequests.yaml
+++ b/code/modules/RebootRequests/RebootRequests.yaml
@@ -50,6 +50,7 @@ components:
               type: array
               items:
                 $ref: "../NAM_Common.yaml#/components/schemas/UUID"
+              maxItems: 100
               description: >-
                 List of devices to reboot. When undefined, the reboot targets the 'default' device (simple use case that
                 wouldn't use locations or devices). Throws an error when creating if there is no 'default' device.
@@ -80,6 +81,7 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/RebootRequest"
+      maxItems: 100
 
   examples:
     RebootRequestCreateImmediateDefaultDevice:

--- a/code/modules/Services/Services.yaml
+++ b/code/modules/Services/Services.yaml
@@ -88,6 +88,7 @@ components:
       description: A list of services accessible to the calling identity
       items:
         $ref: "#/components/schemas/Service"
+      maxItems: 100
       example:
         - id: *uuid-example
           name: "Main Home Internet"

--- a/code/modules/TrustDomainDevices/TrustDomainDevices.yaml
+++ b/code/modules/TrustDomainDevices/TrustDomainDevices.yaml
@@ -171,6 +171,7 @@ components:
           items:
             $ref: "#/components/schemas/BootstrappingProtocol"
           minItems: 1
+          maxItems: 3
           description: |
             Bootstrapping protocols in order of preference (most preferred first).
             The server selects the first protocol compatible with the Trust Domain's
@@ -227,6 +228,7 @@ components:
           items:
             $ref: "#/components/schemas/CredentialType"
           minItems: 1
+          maxItems: 2
           description: |
             Credential types the device supports, ordered by preference (most
             preferred first). The server selects the first type compatible with
@@ -422,6 +424,7 @@ components:
       description: A list of devices registered to a Trust Domain.
       items:
         $ref: "#/components/schemas/TrustDomainDevice"
+      maxItems: 1024
 
   examples:
 

--- a/code/modules/TrustDomains/TrustDomainCapabilities.yaml
+++ b/code/modules/TrustDomains/TrustDomainCapabilities.yaml
@@ -9,6 +9,7 @@ components:
           items:
             $ref: "#/components/schemas/SupportedAccessType"
           minItems: 1
+          maxItems: 4
         supportedPolicies:
           type: object
           description: Map of supported policy types to their capability details
@@ -183,6 +184,7 @@ components:
           items:
             type: string
             enum: ["IP", "FQDN", "CIDR"]
+          maxItems: 3
           description: Supported destination address formats
           example: ["IP", "FQDN", "CIDR"]
       required:
@@ -208,6 +210,7 @@ components:
               - "WPA2-WPA3-Personal"
               - "WPA2-Enterprise"
               - "WPA3-Enterprise"
+          maxItems: 5
           description: Supported Wi-Fi security mode types
           example: ["WPA2-Personal", "WPA3-Personal"]
         passwordConstraints:

--- a/code/modules/TrustDomains/TrustDomains.yaml
+++ b/code/modules/TrustDomains/TrustDomains.yaml
@@ -100,6 +100,7 @@ components:
           $ref: "../Policy.yaml#/components/schemas/Policies"
         accessDetails:
           type: array
+          maxItems: 16
           # Each item grants access for a device to this Trust Domain, scoped by the associated AP/network access device or AP group.
           description: |
             A list of access configurations that define how end-user devices may join the

--- a/code/modules/TrustDomains/TrustDomains.yaml
+++ b/code/modules/TrustDomains/TrustDomains.yaml
@@ -100,7 +100,7 @@ components:
           $ref: "../Policy.yaml#/components/schemas/Policies"
         accessDetails:
           type: array
-          maxItems: 16
+          maxItems: 4
           # Each item grants access for a device to this Trust Domain, scoped by the associated AP/network access device or AP group.
           description: |
             A list of access configurations that define how end-user devices may join the


### PR DESCRIPTION

#### What type of PR is this?

* bug/conformance fix

#### What this PR does / why we need it:

Clears the non-blocking CAMARA Validation findings surfaced by the Commonalities **r4.3** bump (see the validation run on #153), so the two split APIs are clean ahead of the **r3.1 release candidate**:

- **[S-309]** — add `maxItems` to **every** array schema (14 total). Values are anchored to a real limit where one exists, otherwise a modest per-subscriber cap:
  - enum-item arrays → enum size (`protocolPreference` 3, `supportedTypes` 2, `supportedAccessTypes` 4, `supportedDestinationTypes` 3, `supportedSecurityModes` 5)
  - `TrustDomainDeviceList` → 1024 (= `MaxDevicesPolicy` maximum); `EgressAllowedListPolicy` → 1024 (= `EgressPolicyCapability.maxEntries` maximum)
  - subscriber-scoped list responses + reboot target `devices` → 100 (matches the r4.2 `perPage` max)
  - `accessDetails` → 16 (one per access type + headroom — **open to review**)
- **[P-026]** — embed the three mandatory `info.description` template blocks verbatim (markered) in both specs, replacing the prior ad-hoc prose: `authorization-and-authentication`, `additional-error-responses`, and `request-body-strictness` (**new in r4.3**). Source: `code/common/info-description-templates.yaml`.

**[S-313]** (free-form string fields) is intentionally left as-is — the rule's own guidance is *"acceptable if free-form — no fix needed."* Catalogued in #155 for traceability.

#### Which issue(s) this PR fixes:

Fixes #155

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Adds schema constraints (`maxItems`) and standardized description text on a pre-stable (wip / 0.x) API; no endpoint, schema-shape, or scope changes.

#### Special notes for reviewers:

- **Stacked on #153** (the API split). Intended merge order: **#153 → this → the release-plan RC-cut PR**. After #153 squash-merges I rebase this onto `main`, at which point the diff is cleanup-only.
- `maxItems` is a conformance bound only — it does **not** decide the pagination model (**#130**). If pagination is adopted later, these bounds become the per-page / items cap (analogous to how #135 added `maxLength` alongside existing regex bounds purely for conformance).
- The P-026 work here is the mechanical block paste; the richer description / marketing refactor stays in **#143**.
- The `network-access-management` **[P-002]/[P-006]** findings are out of scope here — they clear via the release-plan RC-cut PR that drops the transitional `network-access-management` entry.

#### Changelog input

```
release-note
Add maxItems bounds to all array schemas and embed the mandatory CAMARA info.description template blocks (authorization-and-authentication, additional-error-responses, request-body-strictness) to conform to Commonalities r4.3.
```

#### Additional documentation

```
docs

```
