### PR TITLE
chore: cut r3.1 release candidate — drop network-access-management, bump split APIs to rc (#152)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,17 +33,9 @@ dependencies:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
-  - api_name: network-access-management
-    target_api_version: 0.3.0
-    target_api_status: draft
-    main_contacts:
-      - caubut-charter
-      - mayur007
-      - clundie-CL
-      - benhepworth
   - api_name: network-access-devices
     target_api_version: 0.3.0
-    target_api_status: draft
+    target_api_status: rc
     main_contacts:
       - caubut-charter
       - mayur007
@@ -51,7 +43,7 @@ apis:
       - benhepworth
   - api_name: network-access-domains
     target_api_version: 0.3.0
-    target_api_status: draft
+    target_api_status: rc
     main_contacts:
       - caubut-charter
       - mayur007


### PR DESCRIPTION
> ⚠️ **Draft — depends on #153.** Release-plan-only PR for the **r3.1 RC cut**: it declares the two split APIs as `rc` and restores `target_release_type: pre-release-rc`. It will **fail validation until #153 merges** (P-009: `rc` APIs need their spec files present on `main`, and `network-access-management.yaml` is still an orphan here). Once #153 lands I rebase this onto `main` and it goes green.

#### What type of PR is this?

* chore / release management

#### What this PR does / why we need it:

The final release-plan step of the API split (#152), promoting the repository to the **r3.1 release candidate**:

- **Drop** the transitional `network-access-management` entry — kept as `draft` only so its file wasn't an orphan during the staged split in #154. Removing it clears the standing **[P-002]** (missing `network-access-management.yaml`) and **[P-006]** (no `.feature` for `network-access-management`) findings.
- **Bump** `network-access-devices` and `network-access-domains` from `draft` → `rc`.
- **Restore** `target_release_type: pre-release-rc` (parked at `none` in #154 because `pre-release-rc` rejects any `draft`/`alpha` entry).

Per **[P-022]**, release-plan changes go in their own PR — this is that PR. It carries **no spec/test/doc changes**.

#### Which issue(s) this PR fixes:

Follow-up to #152 (the API split); prepares the r3.1 release candidate (#146).

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Release-plan metadata only.

#### Special notes for reviewers:

- **Merge order:** #153 (split) → #156 (validation cleanup) → **this**. This PR is intentionally red until #153 merges; I'll rebase it onto `main` immediately afterward, at which point the `rc` entries resolve against the on-`main` spec files and validation passes.
- **Sequencing rationale (the P-009 gotcha):** `target_release_type: pre-release-rc` rejects `draft`/`alpha` entries, so the type can only flip to `pre-release-rc` in the same change that brings both APIs to `rc` and drops the transitional `draft` `network-access-management` entry. That's why #154 staged everything as `draft` + `none` first, and this PR completes the cut.

#### Changelog input

```
release-note
Promote network-access-devices and network-access-domains to release-candidate for r3.1 and remove the transitional network-access-management release-plan entry.
```

#### Additional documentation

```
docs

```
